### PR TITLE
feat: add markdownlint configuration

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "default": true,
+    "MD013": {
+      "line_length": 300,
+      "code_blocks": false,
+      "tables": false
+    },
+    "MD033": false,
+    "MD034": false,
+    "MD041": false,
+    "MD032": false,
+    "MD022": false,
+    "MD040": false,
+    "MD060": false
+  },
+  "globs": ["**/*.md"],
+  "ignores": ["node_modules/**", "**/node_modules/**", ".git/**"]
+}


### PR DESCRIPTION
Adds markdownlint-cli2 configuration to enforce consistent markdown formatting across the project.