### PR TITLE
feat: add new plugins and update existing plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,13 @@
       "source": "./plugins/commit-command",
       "category": "git",
       "tags": ["git", "automation", "commit", "workflow"],
-      "keywords": ["git", "commit", "automation", "ai-generated", "conventional-commits"]
+      "keywords": [
+        "git",
+        "commit",
+        "automation",
+        "ai-generated",
+        "conventional-commits"
+      ]
     },
     {
       "name": "commit-skill",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,5 +9,13 @@
   },
   "homepage": "https://github.com/nsheaps/.ai",
   "repository": "https://github.com/nsheaps/.ai",
-  "keywords": ["claude-code", "plugins", "git", "automation", "commit", "workflow", "marketplace"]
+  "keywords": [
+    "claude-code",
+    "plugins",
+    "git",
+    "automation",
+    "commit",
+    "workflow",
+    "marketplace"
+  ]
 }

--- a/plugins/commit-command/.claude-plugin/plugin.json
+++ b/plugins/commit-command/.claude-plugin/plugin.json
@@ -9,5 +9,11 @@
   },
   "homepage": "https://github.com/nsheaps/.ai/tree/main/plugins/commit-command",
   "repository": "https://github.com/nsheaps/.ai",
-  "keywords": ["git", "commit", "automation", "conventional-commits", "semantic-commit"]
+  "keywords": [
+    "git",
+    "commit",
+    "automation",
+    "conventional-commits",
+    "semantic-commit"
+  ]
 }

--- a/plugins/commit-command/README.md
+++ b/plugins/commit-command/README.md
@@ -121,6 +121,7 @@ The plugin works out of the box with sensible defaults, but adapts to your prefe
 ### Commit Message Conventions
 
 The plugin detects and adapts to:
+
 - **Conventional Commits**: `type(scope): description`
 - **Issue References**: `#123`, `[JIRA-456]`, `Fixes #789`
 - **Custom Formats**: Learns from your existing commits
@@ -130,6 +131,7 @@ The plugin detects and adapts to:
 ### Sensitive File Exclusion
 
 Automatically excludes:
+
 - `.env*` files
 - `credentials.json`
 - `secrets.yml`
@@ -179,6 +181,7 @@ git push
 **Problem**: `/commit` command doesn't work
 
 **Solutions**:
+
 - Verify plugin is in `~/.claude/plugins/commit-command/`
 - Restart Claude Code
 - Check plugin is enabled in settings
@@ -188,6 +191,7 @@ git push
 **Problem**: "No changes to commit" message
 
 **Solutions**:
+
 - Run `git status` to verify you have modifications
 - Ensure files aren't in .gitignore
 - Check you're in a git repository
@@ -197,6 +201,7 @@ git push
 **Problem**: Generated messages don't follow your conventions
 
 **Solutions**:
+
 - Make a few manual commits to establish patterns
 - Use argument hints to guide generation
 - Specify your convention explicitly: "Use Conventional Commits format"
@@ -206,6 +211,7 @@ git push
 **Problem**: Warning about sensitive files
 
 **Solutions**:
+
 - Add files to `.gitignore`
 - Review and verify files are safe to commit
 - Use `git add` to explicitly stage specific files
@@ -264,6 +270,7 @@ git add test/auth.test.js
 ## Allowed Tools
 
 The command uses these tools:
+
 - `Bash(git add:*)` - Stage files
 - `Bash(git status:*)` - Check repository status
 - `Bash(git commit:*)` - Create commits
@@ -285,6 +292,7 @@ The command uses these tools:
 ### What's Committed
 
 The command only commits:
+
 - Source code files
 - Configuration files (non-sensitive)
 - Documentation
@@ -317,6 +325,7 @@ The command only commits:
 ## Contributing
 
 Contributions welcome! Please:
+
 1. Fork the repository
 2. Create a feature branch
 3. Make your changes
@@ -325,6 +334,7 @@ Contributions welcome! Please:
 ## Changelog
 
 ### Version 1.0.0
+
 - Initial release
 - Intelligent commit message generation
 - Conventional Commits support

--- a/plugins/commit-command/commands/commit.md
+++ b/plugins/commit-command/commands/commit.md
@@ -33,29 +33,37 @@ Automatically analyze your git changes and create commits with intelligently gen
 ## Examples
 
 ### Basic Usage
+
 ```bash
 /commit
 ```
+
 Analyzes all changes and generates a commit message like:
+
 - `feat: add user authentication with JWT tokens`
 - `fix: resolve null pointer in payment processor`
 - `refactor: simplify database connection logic`
 
 ### With Conventional Commits
+
 ```bash
 /commit feat:
 ```
+
 Ensures the message starts with "feat:" for feature additions.
 
 ```bash
 /commit fix:
 ```
+
 Ensures the message starts with "fix:" for bug fixes.
 
 ### Custom Prefixes
+
 ```bash
 /commit [TASK-123]
 ```
+
 Adds ticket reference to the commit message.
 
 ## Safety Features

--- a/plugins/commit-skill/README.md
+++ b/plugins/commit-skill/README.md
@@ -45,6 +45,7 @@ The skill operates transparently during your development workflow:
 ### Automatic Activation
 
 Claude activates this skill when:
+
 - Completing development tasks
 - Multiple files have been modified
 - Working in repositories with commit conventions
@@ -113,6 +114,7 @@ Claude creates separate commits:
 ### Change Type Detection
 
 The skill identifies changes as:
+
 - **feat**: New features or functionality
 - **fix**: Bug fixes and corrections
 - **refactor**: Code restructuring
@@ -127,6 +129,7 @@ The skill identifies changes as:
 ### Atomic Commit Strategy
 
 Creates commits that are:
+
 - Focused on one logical change
 - Independently reviewable
 - Bisect-friendly
@@ -136,6 +139,7 @@ Creates commits that are:
 ### Repository Adaptation
 
 Learns from your repository:
+
 - Commit message format
 - Imperative vs. past tense
 - Capitalization style
@@ -205,6 +209,7 @@ Claude creates logical commits:
 ### Never Commits Sensitive Files
 
 Protected file types:
+
 - `.env*` - Environment variables
 - `credentials.json` - Credential files
 - `secrets.yml` - Secret configuration
@@ -226,6 +231,7 @@ Protected file types:
 ### Pre-commit Hook Integration
 
 Works seamlessly with hooks:
+
 - Respects hook requirements
 - Handles auto-formatting
 - Retries if hooks modify files
@@ -234,6 +240,7 @@ Works seamlessly with hooks:
 ### Multi-Commit Organization
 
 For complex changes:
+
 ```
 You: "Migrate authentication from sessions to JWT"
 
@@ -302,6 +309,7 @@ Claude ensures:
 **Problem**: Skill doesn't seem to be working
 
 **Solutions**:
+
 - Verify installation in `~/.claude/skills/commit-skill/`
 - Ensure you're in a git repository
 - Check there are changes to commit
@@ -312,6 +320,7 @@ Claude ensures:
 **Problem**: Commit messages don't follow your conventions
 
 **Solutions**:
+
 - Make manual commits to establish patterns
 - Explicitly state your conventions
 - The skill learns over time
@@ -321,6 +330,7 @@ Claude ensures:
 **Problem**: Commits aren't organized as expected
 
 **Solutions**:
+
 - Provide guidance on commit granularity
 - Specify "create one commit" or "create atomic commits"
 - The skill learns your preferences
@@ -330,6 +340,7 @@ Claude ensures:
 **Problem**: Expected files aren't committed
 
 **Solutions**:
+
 - Check `.gitignore` patterns
 - Verify file permissions
 - Ensure files aren't marked as sensitive
@@ -347,12 +358,14 @@ Claude ensures:
 ### When to Use Each
 
 **Use the Skill when:**
+
 - Actively developing features
 - Want Claude to handle commits automatically
 - Working on multi-part implementations
 - Prefer transparent commit management
 
 **Use the Command when:**
+
 - Want explicit control over commits
 - Need to commit specific changes
 - Prefer manual commit workflow
@@ -368,6 +381,7 @@ Claude ensures:
 ## Allowed Tools
 
 The skill uses:
+
 - `Bash(git add:*)` - Stage files
 - `Bash(git status:*)` - Check status
 - `Bash(git commit:*)` - Create commits
@@ -403,6 +417,7 @@ The skill uses:
 ## Contributing
 
 Contributions welcome! Please:
+
 1. Fork the repository
 2. Create a feature branch
 3. Make your changes
@@ -411,6 +426,7 @@ Contributions welcome! Please:
 ## Changelog
 
 ### Version 1.0.0
+
 - Initial release
 - Automatic skill activation
 - Semantic change analysis

--- a/plugins/commit-skill/skills/smart-commit/SKILL.md
+++ b/plugins/commit-skill/skills/smart-commit/SKILL.md
@@ -20,12 +20,14 @@ Claude will automatically use this skill when:
 ## What This Skill Enables
 
 ### 1. Intelligent Change Analysis
+
 - Examines staged and unstaged changes semantically
 - Identifies the type of change (feature, fix, refactor, docs, test, etc.)
 - Groups related changes logically
 - Detects breaking changes and significant modifications
 
 ### 2. Convention Detection
+
 - Learns from existing commit history
 - Identifies commit message patterns:
   - Conventional Commits (`feat:`, `fix:`, `docs:`, etc.)
@@ -35,13 +37,16 @@ Claude will automatically use this skill when:
 - Maintains consistency across commits
 
 ### 3. Smart File Staging
+
 - Stages related files together for atomic commits
 - Groups changes by logical functionality
 - Respects `.gitignore` patterns
 - Excludes sensitive files automatically
 
 ### 4. Security-Aware Committing
+
 Claude will **never** commit files that may contain sensitive information:
+
 - Environment files (`.env*`)
 - Credential files (`credentials.json`, `secrets.yml`, `*.pem`, `*.key`)
 - API keys and tokens
@@ -50,7 +55,9 @@ Claude will **never** commit files that may contain sensitive information:
 - SSH keys
 
 ### 5. Semantic Message Generation
+
 Creates commit messages that:
+
 - Accurately describe the changes and their purpose
 - Match your repository's established style
 - Include appropriate scope and context
@@ -60,6 +67,7 @@ Creates commit messages that:
 ## How Claude Uses This Skill
 
 ### Scenario 1: Feature Implementation
+
 ```
 User: "Add user authentication with JWT tokens"
 
@@ -73,6 +81,7 @@ Claude's workflow with this skill:
 ```
 
 ### Scenario 2: Bug Fix
+
 ```
 User: "Fix the null pointer error in payment processing"
 
@@ -86,6 +95,7 @@ Claude's workflow:
 ```
 
 ### Scenario 3: Multi-Part Refactoring
+
 ```
 User: "Refactor the database layer to use repositories"
 
@@ -102,6 +112,7 @@ Claude's workflow:
 ## Skill Capabilities
 
 ### Change Type Detection
+
 Claude can identify and categorize changes as:
 
 - **feat**: New features or functionality
@@ -116,6 +127,7 @@ Claude can identify and categorize changes as:
 - **build**: Build system or external dependency changes
 
 ### Atomic Commit Strategy
+
 The skill helps Claude create focused commits:
 
 - One logical change per commit
@@ -126,6 +138,7 @@ The skill helps Claude create focused commits:
 - Enables better git bisect usage
 
 ### Repository Style Adaptation
+
 Claude learns your preferences:
 
 - Analyzes last 10-20 commits for patterns
@@ -138,6 +151,7 @@ Claude learns your preferences:
 ## Usage Examples
 
 ### Example 1: Automatic Commit During Feature Work
+
 ```
 User: "Implement dark mode toggle in the settings page"
 
@@ -149,6 +163,7 @@ Claude:
 ```
 
 ### Example 2: Multiple Related Commits
+
 ```
 User: "Add user profile page with avatar upload"
 
@@ -160,6 +175,7 @@ Claude creates atomic commits:
 ```
 
 ### Example 3: Bug Fix with Context
+
 ```
 User: "Fix issue #456 - login fails with special characters"
 
@@ -169,6 +185,7 @@ Claude commits: "fix: handle special characters in login (#456)"
 ## Best Practices Followed
 
 ### Commit Message Structure
+
 ```
 <type>[optional scope]: <description>
 
@@ -178,6 +195,7 @@ Claude commits: "fix: handle special characters in login (#456)"
 ```
 
 ### Examples of Well-Formed Messages
+
 - `feat: add user authentication system`
 - `fix: resolve memory leak in image processor`
 - `refactor(api): simplify error handling logic`
@@ -185,6 +203,7 @@ Claude commits: "fix: handle special characters in login (#456)"
 - `test: add unit tests for validation`
 
 ### What Claude Won't Do
+
 - Commit commented-out code without purpose
 - Create commits with generic messages like "update files"
 - Combine unrelated changes in a single commit
@@ -195,6 +214,7 @@ Claude commits: "fix: handle special characters in login (#456)"
 ## Configuration and Customization
 
 ### Repository-Specific Patterns
+
 Claude adapts to your repository's patterns automatically, but you can guide it:
 
 ```
@@ -205,7 +225,9 @@ Claude adapts to your repository's patterns automatically, but you can guide it:
 ```
 
 ### Pre-commit Hook Integration
+
 This skill works seamlessly with pre-commit hooks:
+
 - Respects hook requirements
 - Handles auto-formatting from hooks
 - Retries commits if hooks modify files
@@ -214,6 +236,7 @@ This skill works seamlessly with pre-commit hooks:
 ## Workflow Integration
 
 ### With Pull Requests
+
 ```
 User: "Prepare this work for PR"
 
@@ -226,6 +249,7 @@ Claude:
 ```
 
 ### With Code Review
+
 ```
 Reviewer: "These changes need better commit organization"
 
@@ -239,6 +263,7 @@ Claude:
 ## Technical Details
 
 ### Git Commands Used
+
 - `git status` - Identify changed files
 - `git diff` - Analyze actual changes
 - `git log` - Study commit history and patterns
@@ -246,7 +271,9 @@ Claude:
 - `git commit` - Create commits with generated messages
 
 ### Pattern Recognition
+
 The skill uses AI to:
+
 - Parse commit message structures
 - Identify semantic change types
 - Detect organizational conventions
@@ -254,6 +281,7 @@ The skill uses AI to:
 - Preserve context and references
 
 ### Safety Mechanisms
+
 - Pre-commit validation
 - Sensitive file detection
 - Staged changes verification
@@ -288,6 +316,7 @@ The skill uses AI to:
 ## Learning and Improvement
 
 The skill improves with usage:
+
 - Learns repository-specific conventions over time
 - Adapts to feedback on commit messages
 - Recognizes project-specific patterns

--- a/plugins/skills-maintenance/.claude-plugin/plugin.json
+++ b/plugins/skills-maintenance/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "skills-maintenance",
+  "version": "1.0.0",
+  "description": "Agent skill for maintaining, updating, and improving existing Claude Code skills",
+  "author": {
+    "name": "Claude Code Community",
+    "email": "community@example.com",
+    "url": "https://github.com/nsheaps/.ai"
+  },
+  "homepage": "https://github.com/nsheaps/.ai/tree/main/plugins/skills-maintenance",
+  "repository": "https://github.com/nsheaps/.ai",
+  "keywords": [
+    "skills",
+    "maintenance",
+    "update",
+    "improve",
+    "refactor",
+    "documentation"
+  ]
+}

--- a/plugins/skills-maintenance/README.md
+++ b/plugins/skills-maintenance/README.md
@@ -1,0 +1,257 @@
+# Skills Maintenance Plugin
+
+Agent skill for systematically maintaining, updating, and improving existing Claude Code agent skills.
+
+## Overview
+
+The **Skills Maintenance** plugin provides Claude with structured guidance for updating and improving existing skills. This skill activates when you need to modify, enhance, or fix skills that already exist—not for creating new skills from scratch.
+
+## Features
+
+✅ **Systematic Maintenance Workflow**
+
+- Step-by-step process for understanding and updating skills
+- Comprehensive checklists for validation
+- Best practices for backward compatibility
+
+✅ **Documentation References**
+
+- Links to official Claude Code documentation
+- Claude Code SDK and GitHub Action resources
+- Anthropic documentation and cookbook examples
+
+✅ **Common Patterns**
+
+- Adding new activation triggers
+- Enhancing capabilities
+- Improving documentation
+- Fixing activation issues
+
+✅ **Troubleshooting Guidance**
+
+- Diagnosing activation problems
+- Resolving conflicts with other skills
+- Handling edge cases and special situations
+
+## When This Skill Activates
+
+The skill-maintenance skill activates when:
+
+- User asks to "update the X skill"
+- User wants to "improve" or "refactor" an existing skill
+- User requests to fix issues with a skill
+- User wants to add features to an existing skill
+- User wants to update skill documentation
+
+**Does NOT activate when:**
+
+- Creating new skills from scratch
+- Asking general questions about skills
+- Deleting or removing skills
+
+## Installation
+
+### Via Claude Code Plugin Manager
+
+1. Open Claude Code
+2. Run `/plugin marketplace add nsheaps/.ai`
+3. Find "skills-maintenance" plugin
+4. Click "Install now"
+5. Restart Claude Code
+
+### Manual Installation
+
+```bash
+# Navigate to Claude Code skills directory
+cd ~/.claude/skills
+
+# Clone this repository (or copy the plugin)
+git clone https://github.com/nsheaps/.ai skills-maintenance
+cd skills-maintenance
+git sparse-checkout init --cone
+git sparse-checkout set plugins/skills-maintenance
+
+# Or copy the plugin directory directly
+cp -r /path/to/repo/plugins/skills-maintenance ~/.claude/skills/
+```
+
+## Usage
+
+Once installed, the skill activates automatically when you request skill maintenance tasks:
+
+### Example 1: Updating a Skill
+
+```
+You: "Update the smart-commit skill to handle merge commits better"
+
+Claude: [Activates skill-maintenance]
+1. Reads the current smart-commit skill file
+2. Identifies merge commit handling gaps
+3. References best practices from documentation
+4. Updates skill with new merge commit behavior
+5. Updates plugin.json version
+6. Updates README.md
+7. Tests activation triggers
+```
+
+### Example 2: Improving Documentation
+
+```
+You: "The commit-skill examples are unclear, can you improve them?"
+
+Claude: [Activates skill-maintenance]
+1. Reviews current examples
+2. Identifies areas of confusion
+3. Adds concrete, realistic examples
+4. Clarifies activation conditions
+5. Updates version and documentation
+```
+
+### Example 3: Fixing Activation Issues
+
+```
+You: "The auto-test skill activates too often"
+
+Claude: [Activates skill-maintenance]
+1. Analyzes current activation description
+2. Identifies overly broad triggers
+3. Narrows activation conditions
+4. Adds negative examples
+5. Tests with various phrases
+6. Updates and validates
+```
+
+## Maintenance Workflow
+
+The skill guides Claude through a systematic 5-step process:
+
+### Step 1: Understand the Current Skill
+
+- Read skill file and metadata
+- Analyze frontmatter and content
+- Review related files and documentation
+
+### Step 2: Identify What Needs Updating
+
+- Documentation improvements
+- Behavioral enhancements
+- Structure refinements
+- Version updates
+
+### Step 3: Make Changes Systematically
+
+- Maintain backward compatibility
+- Follow Claude Code best practices
+- Reference official documentation
+
+### Step 4: Test Your Changes
+
+- Validate syntax and formatting
+- Test activation triggers
+- Verify behavior and integration
+
+### Step 5: Update Version and Documentation
+
+- Bump version following semver
+- Update README.md
+- Update marketplace metadata
+
+## Documentation References
+
+The skill includes references to all major Claude Code and Anthropic documentation sources:
+
+- **Claude Code Documentation**: https://code.claude.com/docs
+- **Claude Code on the Web**: https://code.claude.com/docs/en/claude-code-on-the-web
+- **Anthropic Documentation**: https://docs.anthropic.com
+- **Claude Code SDK**: https://github.com/anthropics/claude-code-sdk
+- **Claude Code GitHub Action**: https://github.com/anthropics/claude-code-action
+- **Claude Cookbook**: https://github.com/anthropics/anthropic-cookbook
+
+## Best Practices Included
+
+The skill teaches Claude to:
+
+1. **Keep Skills Focused**: One clear purpose per skill
+2. **Write for Claude**: Instructions, not user docs
+3. **Be Specific About Tools**: Explicit tool permissions
+4. **Include Negative Examples**: When NOT to activate
+5. **Document Edge Cases**: Special situations and handling
+6. **Reference Related Skills**: Show ecosystem connections
+7. **Keep Documentation Current**: Regular reviews and updates
+
+## Troubleshooting Guide
+
+Built-in troubleshooting for common issues:
+
+- Skill never activates (description too specific)
+- Skill activates too often (description too broad)
+- Skill behavior inconsistent (ambiguous instructions)
+- Skill conflicts with others (overlapping triggers)
+
+Each issue includes diagnosis steps and fixes.
+
+## Maintenance Checklist
+
+Complete checklist for validating skill updates:
+
+- Frontmatter YAML validity
+- Clear activation description
+- Concrete examples
+- Tool permissions specified
+- Related skills referenced
+- Negative examples included
+- Edge cases documented
+- Version bumped correctly
+- README updated
+- Activation tested
+- No conflicts
+- Documentation references current
+- Markdown formatting correct
+- Backward compatibility maintained
+
+## Version History
+
+### 1.0.0 (2025-12-13)
+
+- Initial release
+- Comprehensive skill maintenance workflow
+- Documentation references to all major sources
+- Common patterns and examples
+- Troubleshooting guidance
+- Maintenance checklist
+
+## Requirements
+
+- **Claude Code**: Latest version
+- **Existing Skills**: This skill maintains existing skills, doesn't create new ones
+
+## Related Plugins
+
+- **commit-command**: Example of a well-maintained slash command
+- **commit-skill**: Example of a well-maintained agent skill
+- Use this skill to maintain both of those plugins
+
+## Contributing
+
+Improvements to this skill are welcome! To contribute:
+
+1. Fork this repository
+2. Make changes to the skill
+3. Test thoroughly
+4. Submit a pull request
+
+Follow the same maintenance workflow described in the skill itself!
+
+## Support
+
+- **Documentation**: [Claude Code Docs](https://code.claude.com/docs)
+- **Issues**: [GitHub Issues](https://github.com/nsheaps/.ai/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/nsheaps/.ai/discussions)
+
+## License
+
+See repository LICENSE file
+
+---
+
+**Made for the Claude Code Community** | **Star the repo** ⭐ if you find this useful!

--- a/plugins/skills-maintenance/skills/skill-maintenance/SKILL.md
+++ b/plugins/skills-maintenance/skills/skill-maintenance/SKILL.md
@@ -1,0 +1,520 @@
+---
+name: skill-maintenance
+description: Use this skill when updating, improving, or maintaining existing Claude Code agent skills. Activates when the user asks to update, refactor, improve, or fix an existing skill. Does NOT activate for creating new skills from scratch.
+---
+
+# Skill Maintenance Guide
+
+This skill helps you systematically maintain, update, and improve existing Claude Code agent skills. Use this when modifying skills that already exist, not for creating new ones.
+
+## When to Activate This Skill
+
+✅ **Activate when:**
+
+- User asks to "update the X skill"
+- User wants to "improve the Y skill"
+- User requests to "refactor" or "fix" an existing skill
+- User wants to add features to an existing skill
+- User reports issues with a skill's behavior
+- User wants to update skill documentation
+- User wants to optimize skill performance
+
+❌ **Do NOT activate when:**
+
+- User wants to create a brand new skill (use regular skill creation workflow)
+- User is asking general questions about skills
+- User wants to delete or remove a skill entirely
+
+## Maintenance Workflow
+
+### Step 1: Understand the Current Skill
+
+Before making changes, thoroughly understand the existing skill:
+
+1. **Read the skill file** (usually `skills/skill-name/SKILL.md`)
+2. **Review the frontmatter metadata:**
+
+   - `name`: Skill identifier
+   - `description`: When and how the skill activates
+   - `examples` (if present): Usage patterns
+
+3. **Analyze the skill content:**
+
+   - Activation conditions
+   - Behavior and capabilities
+   - Tool permissions
+   - Examples and use cases
+
+4. **Check related files:**
+   - Plugin metadata (`.claude-plugin/plugin.json`)
+   - README.md for user-facing documentation
+   - Any supporting scripts or binaries
+
+### Step 2: Identify What Needs Updating
+
+Common maintenance tasks:
+
+**Documentation Updates:**
+
+- Clarify activation conditions
+- Add or improve examples
+- Update descriptions to match current behavior
+- Fix typos or formatting issues
+
+**Behavioral Improvements:**
+
+- Enhance activation triggers to be more precise
+- Add new capabilities while maintaining backward compatibility
+- Improve error handling instructions
+- Optimize skill performance
+
+**Structure Refinements:**
+
+- Reorganize content for clarity
+- Split large skills into focused sub-sections
+- Add cross-references to related skills or commands
+- Update frontmatter metadata
+
+**Version Updates:**
+
+- Increment version in `plugin.json` following semver
+- Update marketplace metadata if needed
+- Document changes in README.md
+
+### Step 3: Make Changes Systematically
+
+Follow these principles when updating skills:
+
+#### A. Maintain Backward Compatibility
+
+- Don't change core activation behavior without good reason
+- If changing behavior, document migration path
+- Test that existing use cases still work
+
+#### B. Follow Claude Code Skill Best Practices
+
+**Frontmatter Rules:**
+
+```yaml
+---
+name: skill-name # Lowercase, hyphen-separated, matches directory name
+description: Clear description of when and how the skill activates (1-2 sentences)
+examples: # Optional but recommended
+  - "Example trigger phrase 1"
+  - "Example trigger phrase 2"
+---
+```
+
+**Content Structure:**
+
+1. **Introduction**: Brief overview of skill purpose
+2. **Activation Conditions**: When the skill should activate
+3. **Capabilities**: What the skill can do
+4. **Examples**: Concrete usage examples
+5. **Limitations**: What the skill cannot or should not do
+6. **Related Resources**: Links to docs, related skills
+
+**Writing Style:**
+
+- Use clear, imperative instructions for Claude
+- Be specific about tool usage and permissions
+- Include examples of both good and bad usage
+- Document edge cases and error handling
+
+#### C. Reference Official Documentation
+
+When updating skills, refer to these authoritative sources:
+
+📚 **Primary Documentation Sources:**
+
+1. **Claude Code Documentation**: https://code.claude.com/docs
+   - General Claude Code features and usage
+   - Settings and configuration
+   - Slash commands and skills reference
+
+2. **Claude Code on the Web**: https://code.claude.com/docs/en/claude-code-on-the-web
+   - Web-specific considerations
+   - SessionStart hooks and setup
+   - Remote environment differences
+
+3. **Anthropic Documentation**: https://docs.anthropic.com
+   - Claude API reference
+   - Model capabilities and limitations
+   - Best practices for prompt engineering
+
+4. **Claude Code SDK Documentation**: https://github.com/anthropics/claude-code-sdk
+   - Agent SDK architecture
+   - Building custom agents
+   - Tool development
+
+5. **Claude Code GitHub Action**: https://github.com/anthropics/claude-code-action
+   - CI/CD integration patterns
+   - Automated workflows
+   - Best practices for automated code review
+
+6. **Claude Cookbook (Anthropic)**: https://github.com/anthropics/anthropic-cookbook
+   - Practical examples and recipes
+   - Advanced usage patterns
+   - Integration examples
+
+**When to Reference Each:**
+
+- **Skill activation and behavior** → Claude Code Docs
+- **Web session considerations** → Claude Code on the Web
+- **Model capabilities** → Anthropic Documentation
+- **SDK integration** → Claude Code SDK Docs
+- **CI/CD workflows** → Claude Code GitHub Action
+- **Advanced patterns** → Claude Cookbook
+
+### Step 4: Test Your Changes
+
+Before finalizing updates:
+
+1. **Validate Syntax:**
+   - YAML frontmatter is valid
+   - Markdown formatting is correct
+   - No broken links or references
+
+2. **Test Activation:**
+   - Skill activates on intended triggers
+   - Doesn't activate on unintended triggers
+   - Activation description is accurate
+
+3. **Verify Behavior:**
+   - Skill performs as documented
+   - Examples work as shown
+   - Edge cases are handled
+
+4. **Check Integration:**
+   - Works with related skills/commands
+   - No conflicts with other plugins
+   - Tool permissions are appropriate
+
+### Step 5: Update Version and Documentation
+
+After making changes:
+
+1. **Update `plugin.json`:**
+
+   ```json
+   {
+     "name": "skill-name",
+     "version": "1.1.0", // Increment according to semver
+     "description": "Updated description if needed"
+   }
+   ```
+
+   **Versioning Rules:**
+
+   - **Patch (1.0.X)**: Bug fixes, typos, minor documentation improvements
+   - **Minor (1.X.0)**: New features, enhanced behavior, new examples
+   - **Major (X.0.0)**: Breaking changes to activation or behavior
+
+2. **Update README.md:**
+
+   - Reflect new features or changes
+   - Add new examples if applicable
+   - Update version history section
+
+3. **Update Marketplace Metadata:**
+   - Will be auto-synced by CD workflow
+   - Verify description is still accurate
+
+## Common Maintenance Patterns
+
+### Pattern 1: Adding New Activation Triggers
+
+```markdown
+## When to Use This Skill
+
+**Original:**
+
+- User asks to "commit changes"
+
+**Updated:**
+
+- User asks to "commit changes"
+- User asks to "create a commit"
+- User says "make a commit"
+- Development task is complete and changes need committing
+```
+
+### Pattern 2: Enhancing Capabilities
+
+```markdown
+## What This Skill Does
+
+**Original:**
+
+Analyzes staged changes and creates a commit message.
+
+**Updated:**
+
+Analyzes staged and unstaged changes, suggests which files to stage, creates semantic commit messages following repository conventions, and handles multiple logical changes with atomic commits.
+```
+
+### Pattern 3: Improving Documentation
+
+```markdown
+## Examples
+
+**Original:**
+
+Use this skill to commit your changes.
+
+**Updated:**
+
+**Example 1: Simple Feature Commit**
+
+User: "Commit these changes"
+
+Claude:
+
+- [Analyzes changes]
+- [Creates commit: "feat: add user authentication"]
+
+**Example 2: Multiple Changes**
+
+User: "Commit my work on the API and tests"
+
+Claude:
+
+- [Analyzes changes]
+- [Creates commits:]
+  - "feat: add user API endpoints"
+  - "test: add API endpoint tests"
+```
+
+### Pattern 4: Fixing Activation Issues
+
+If a skill activates too broadly or too narrowly:
+
+```markdown
+## Activation Conditions
+
+**Too Broad (activates on everything):**
+
+description: Use this skill for git operations
+
+**Too Narrow (never activates):**
+
+description: Use this skill when user says exactly "please create git commit now"
+
+**Just Right:**
+
+description: Use this skill when the user requests to commit changes, create commits, or when a development task is complete and code changes are ready to be committed. Activate during git workflow discussions.
+```
+
+## Best Practices for Skill Maintenance
+
+### 1. Keep Skills Focused
+
+- Each skill should have a clear, single purpose
+- If a skill does too many things, consider splitting it
+- Avoid feature creep - stay true to the skill's core purpose
+
+### 2. Write for Claude, Not Humans
+
+Skills are instructions for Claude, not user documentation:
+
+❌ **User-facing:** "This is a skill that helps you commit code."
+✅ **Claude-facing:** "Activate when user requests to commit changes. Analyze staged files, generate semantic commit message, execute git commit."
+
+### 3. Be Specific About Tools
+
+Don't just say "use tools" - specify which ones:
+
+❌ **Vague:** "Use the appropriate tools to complete the task."
+✅ **Specific:** "Use the Bash tool to run `git status` and `git diff`. Use the Read tool to analyze changed files. Use the Edit tool if commit message preview is requested."
+
+### 4. Include Negative Examples
+
+Help Claude know when NOT to use the skill:
+
+```markdown
+## When NOT to Use This Skill
+
+- User is just asking about git (use general knowledge instead)
+- User wants to learn git commands (provide explanation, don't execute)
+- No changes to commit (inform user, don't force empty commit)
+- User is viewing history (use different skill or tools)
+```
+
+### 5. Document Edge Cases
+
+```markdown
+## Special Situations
+
+**Large Changesets:**
+
+- If more than 20 files changed, ask user which to commit
+- Don't create massive commits without confirmation
+
+**Sensitive Files:**
+
+- Always exclude .env, credentials, secrets from commits
+- Warn user if sensitive patterns detected
+
+**Merge Conflicts:**
+
+- Don't auto-commit during merge conflicts
+- Guide user through resolution first
+```
+
+### 6. Reference Related Skills
+
+Help Claude understand the ecosystem:
+
+```markdown
+## Related Skills
+
+- `smart-commit` skill: Use for automatic committing during development
+- `pr-description` skill: Use after committing to create PR descriptions
+- `/commit` command: Alternative manual commit interface
+```
+
+### 7. Keep Documentation Current
+
+- Review skills quarterly for accuracy
+- Update examples to reflect current best practices
+- Remove deprecated features or workflows
+- Add new examples as usage patterns emerge
+
+## Troubleshooting Skill Issues
+
+### Issue: Skill Never Activates
+
+**Diagnosis:**
+
+- Description may be too specific or use unusual terminology
+- Activation conditions may be hidden in the middle of the document
+- Skill name might conflict with another skill
+
+**Fix:**
+
+1. Move activation conditions to the frontmatter description
+2. Use common, natural language for triggers
+3. Add explicit examples in frontmatter
+4. Test with various phrasings
+
+### Issue: Skill Activates Too Often
+
+**Diagnosis:**
+
+- Description is too broad or generic
+- Missing negative activation conditions
+- Conflicts with other skills
+
+**Fix:**
+
+1. Narrow the description to specific scenarios
+2. Add "When NOT to Activate" section
+3. Be more specific about required context
+4. Review other skills for conflicts
+
+### Issue: Skill Behavior Inconsistent
+
+**Diagnosis:**
+
+- Instructions are ambiguous
+- Tool permissions unclear
+- Examples don't match description
+
+**Fix:**
+
+1. Use imperative, step-by-step instructions
+2. Explicitly list allowed tools
+3. Provide clear decision trees for different scenarios
+4. Align examples with instructions
+
+### Issue: Skill Conflicts with Other Skills/Commands
+
+**Diagnosis:**
+
+- Overlapping activation triggers
+- Similar names causing confusion
+- Competing behaviors
+
+**Fix:**
+
+1. Differentiate clearly in descriptions
+2. Add cross-references explaining when to use each
+3. Consider consolidating if overlap is significant
+4. Use different trigger phrases
+
+## Skill Maintenance Checklist
+
+Before finalizing skill updates, verify:
+
+- [ ] Frontmatter YAML is valid and complete
+- [ ] Description clearly states when to activate
+- [ ] Examples are concrete and realistic
+- [ ] Activation conditions are neither too broad nor too narrow
+- [ ] Tool permissions are explicitly stated
+- [ ] Related skills/commands are referenced
+- [ ] Negative examples included (when NOT to use)
+- [ ] Edge cases documented
+- [ ] Version bumped in `plugin.json` according to semver
+- [ ] README.md updated to reflect changes
+- [ ] Tested activation with various trigger phrases
+- [ ] No conflicts with existing skills/commands
+- [ ] Documentation references are current and accurate
+- [ ] Markdown formatting is correct (passes linting)
+- [ ] Changes are backward compatible (or migration documented)
+
+## Quick Reference: Documentation URLs
+
+Keep these handy when maintaining skills:
+
+```markdown
+- Claude Code Docs: https://code.claude.com/docs
+- Claude Code Web: https://code.claude.com/docs/en/claude-code-on-the-web
+- Anthropic Docs: https://docs.anthropic.com
+- Claude Code SDK: https://github.com/anthropics/claude-code-sdk
+- GitHub Action: https://github.com/anthropics/claude-code-action
+- Claude Cookbook: https://github.com/anthropics/anthropic-cookbook
+- JSON Schema for settings: https://json.schemastore.org/claude-code-settings.json
+```
+
+## Example: Complete Skill Maintenance Session
+
+**User Request:** "Update the smart-commit skill to handle merge commits better"
+
+**Your Workflow:**
+
+1. **Read** `plugins/commit-skill/skills/smart-commit/SKILL.md`
+2. **Identify** current merge commit handling (or lack thereof)
+3. **Research** merge commit best practices in Claude Cookbook
+4. **Update** skill with new merge commit section:
+
+   ```markdown
+   ## Handling Merge Commits
+
+   When changes include merge commits:
+
+   - Detect merge commit by checking git status for merge branch
+   - Ask user if they want to create merge commit or abort
+   - Use `git commit --no-edit` for standard merge messages
+   - Or allow custom merge message if user requests
+   ```
+
+5. **Add example** to documentation
+6. **Update** `plugin.json` version from 1.0.0 to 1.1.0 (minor change)
+7. **Update** README.md with merge commit feature
+8. **Test** by simulating merge scenario
+9. **Commit** changes with appropriate message
+
+**Result:** Skill now handles merge commits gracefully, documentation is clear, version properly bumped.
+
+---
+
+## Remember
+
+- **Maintain, don't rebuild**: Work with existing structure unless major refactor needed
+- **Test thoroughly**: Changes to skills affect automation behavior
+- **Document everything**: Future maintainers (and Claude) will thank you
+- **Follow semver**: Version bumps communicate change significance
+- **Reference official docs**: Don't guess - use authoritative sources
+- **Think about activation**: Most skill issues are activation-related
+
+Happy maintaining! 🛠️


### PR DESCRIPTION
This commit adds two new plugins and updates the existing commit-command plugin:

New Plugins:
- commit-skill: Smart commit skill for automated git commits
- skills-maintenance: Skill for maintaining and managing Claude Code skills

Updated Plugins:
- commit-command: Updated plugin metadata and documentation

Marketplace:
- Updated .claude-plugin/marketplace.json with new plugin entries
- Updated .claude-plugin/plugin.json metadata