### PR TITLE
feat: add reusable claude-debug GitHub action

### DIFF
--- a/.github/actions/claude-debug/EXAMPLES.md
+++ b/.github/actions/claude-debug/EXAMPLES.md
@@ -1,0 +1,604 @@
+# Claude Debug Action - Usage Examples
+
+This document provides real-world examples of using the Claude Debug Action in various scenarios.
+
+## Table of Contents
+
+- [Basic Usage](#basic-usage)
+- [Repository Dispatch](#repository-dispatch)
+- [Multi-Stage Workflows](#multi-stage-workflows)
+- [External Repository Integration](#external-repository-integration)
+- [Monitoring and Alerting](#monitoring-and-alerting)
+- [CI/CD Integration](#cicd-integration)
+
+---
+
+## Basic Usage
+
+### Simple Debug Information Extraction
+
+```yaml
+name: Claude Debug
+
+on: [push, pull_request]
+
+jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get Claude Debug Info
+        uses: ./.github/actions/claude-debug
+        id: debug
+
+      - name: Show Session Info
+        run: |
+          echo "Session: ${{ steps.debug.outputs.session-id }}"
+          echo "Branch: ${{ steps.debug.outputs.git-branch }}"
+```
+
+### After Claude Code Automation
+
+```yaml
+name: Claude Automation with Debug
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: 'Task for Claude'
+        required: true
+
+jobs:
+  automate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Claude Code Task
+        run: |
+          # Your Claude Code automation
+          claude-code --task "${{ github.event.inputs.task }}"
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: Debug Claude Session
+        uses: ./.github/actions/claude-debug
+        id: debug
+        with:
+          continue: true
+          extract-logs: true
+
+      - name: Verify Success
+        run: |
+          if [ "${{ steps.debug.outputs.session-status }}" != "success" ]; then
+            echo "Task failed: ${{ steps.debug.outputs.error }}"
+            exit 1
+          fi
+```
+
+---
+
+## Repository Dispatch
+
+### Triggering from External Repository
+
+In your external repository, trigger the debug action:
+
+```yaml
+name: Request Debug Info
+
+on:
+  workflow_dispatch:
+
+jobs:
+  trigger-debug:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to Debug Repository
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          repository: nsheaps/.ai
+          event-type: claude-debug-request
+          client-payload: |
+            {
+              "source_repo": "${{ github.repository }}",
+              "request_id": "${{ github.run_id }}",
+              "issue_number": "${{ github.event.issue.number }}",
+              "ref": "main",
+              "continue": true,
+              "extract_logs": false,
+              "webhook_url": "https://api.example.com/webhooks/debug"
+            }
+```
+
+### Receiving Debug Results via Webhook
+
+```javascript
+// Express.js webhook handler
+app.post('/webhooks/debug', (req, res) => {
+  const {
+    request_id,
+    source_repo,
+    debug_info,
+    git_context,
+    workflow
+  } = req.body;
+
+  console.log(`Debug info received for ${source_repo}`);
+  console.log(`Session ID: ${debug_info.session_id}`);
+  console.log(`Status: ${debug_info.session_status}`);
+
+  // Store in database, send notifications, etc.
+
+  res.status(200).send('OK');
+});
+```
+
+### Receiving Debug Results via PR Comment
+
+The repository dispatch workflow automatically posts results back to the source PR:
+
+```yaml
+# In nsheaps/.ai repository (repository-dispatch-debug.yml handles this)
+# External repo will receive a comment like:
+
+## 🤖 Claude Code Debug Information
+
+**Session ID**: `sess_abc123`
+**Status**: ✅ success
+**Claude Version**: `1.0.0`
+
+### Git Context
+- **Branch**: `main`
+- **Commit**: `a1b2c3d`
+- **Status**: `clean`
+```
+
+---
+
+## Multi-Stage Workflows
+
+### Sequential Claude Operations
+
+```yaml
+name: Multi-Stage Claude Workflow
+
+on:
+  workflow_dispatch:
+
+jobs:
+  multi-stage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Stage 1: Code Analysis
+      - name: Analyze Code
+        run: |
+          claude-code --task "Analyze code quality"
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: Debug Stage 1
+        uses: ./.github/actions/claude-debug
+        id: stage1
+        with:
+          continue: false  # New session
+
+      # Stage 2: Fix Issues
+      - name: Fix Issues
+        run: |
+          claude-code --continue --task "Fix issues found"
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: Debug Stage 2
+        uses: ./.github/actions/claude-debug
+        id: stage2
+        with:
+          continue: true  # Continue from stage 1
+
+      # Stage 3: Verify Fixes
+      - name: Verify Fixes
+        run: |
+          claude-code --continue --task "Verify all fixes"
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: Debug Stage 3
+        uses: ./.github/actions/claude-debug
+        id: stage3
+        with:
+          continue: true
+
+      # Validate session chain
+      - name: Verify Session Continuity
+        run: |
+          echo "Stage 1: ${{ steps.stage1.outputs.session-id }}"
+          echo "Stage 2: ${{ steps.stage2.outputs.session-id }} (prev: ${{ steps.stage2.outputs.previous-session-id }})"
+          echo "Stage 3: ${{ steps.stage3.outputs.session-id }} (prev: ${{ steps.stage3.outputs.previous-session-id }})"
+
+          # Verify chain
+          if [ "${{ steps.stage2.outputs.previous-session-id }}" == "${{ steps.stage1.outputs.session-id }}" ] && \
+             [ "${{ steps.stage3.outputs.previous-session-id }}" == "${{ steps.stage2.outputs.session-id }}" ]; then
+            echo "✅ Session chain verified"
+          else
+            echo "❌ Session chain broken"
+            exit 1
+          fi
+```
+
+---
+
+## External Repository Integration
+
+### Using the Action from External Repos
+
+In any external repository:
+
+```yaml
+name: Use Claude Debug Action
+
+on: [push]
+
+jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Reference the action from nsheaps/.ai
+      - name: Debug Claude Session
+        uses: nsheaps/.ai/.github/actions/claude-debug@main
+        id: debug
+        with:
+          working-directory: .
+          continue: true
+
+      - name: Use Debug Info
+        run: |
+          echo "Session ID: ${{ steps.debug.outputs.session-id }}"
+```
+
+### Cross-Organization Monitoring
+
+Monitor Claude sessions across multiple organization repositories:
+
+```yaml
+name: Org-Wide Claude Monitor
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'  # Every 6 hours
+
+jobs:
+  monitor:
+    strategy:
+      matrix:
+        repo:
+          - org/repo1
+          - org/repo2
+          - org/repo3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Target Repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ matrix.repo }}
+          token: ${{ secrets.ORG_PAT }}
+
+      - name: Debug Claude Session
+        uses: nsheaps/.ai/.github/actions/claude-debug@main
+        id: debug
+        continue-on-error: true
+
+      - name: Report to Central Dashboard
+        run: |
+          curl -X POST https://dashboard.example.com/api/claude-sessions \
+            -H "Authorization: Bearer ${{ secrets.DASHBOARD_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "repository": "${{ matrix.repo }}",
+              "session_id": "${{ steps.debug.outputs.session-id }}",
+              "status": "${{ steps.debug.outputs.session-status }}",
+              "branch": "${{ steps.debug.outputs.git-branch }}",
+              "commit": "${{ steps.debug.outputs.git-commit }}",
+              "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
+            }'
+```
+
+---
+
+## Monitoring and Alerting
+
+### Slack Notifications
+
+```yaml
+name: Claude Debug with Slack
+
+on: [workflow_dispatch]
+
+jobs:
+  debug-and-notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Debug Claude Session
+        uses: ./.github/actions/claude-debug
+        id: debug
+
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@v1
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+          payload: |
+            {
+              "text": "Claude Debug Report",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "🤖 Claude Code Debug Report"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Session ID:*\n`${{ steps.debug.outputs.session-id }}`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Status:*\n${{ steps.debug.outputs.session-status }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\n`${{ steps.debug.outputs.git-branch }}`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Commit:*\n`${{ steps.debug.outputs.git-commit }}`"
+                    }
+                  ]
+                }
+              ]
+            }
+
+      - name: Alert on Error
+        if: steps.debug.outputs.error != ''
+        uses: slackapi/slack-github-action@v1
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_ALERTS }}
+          payload: |
+            {
+              "text": "⚠️ Claude Debug Error",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Error:*\n```${{ steps.debug.outputs.error }}```"
+                  }
+                }
+              ]
+            }
+```
+
+### DataDog Metrics
+
+```yaml
+- name: Send Metrics to DataDog
+  run: |
+    # Send session metrics
+    curl -X POST "https://api.datadoghq.com/api/v1/series" \
+      -H "DD-API-KEY: ${{ secrets.DD_API_KEY }}" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "series": [
+          {
+            "metric": "claude.session.completed",
+            "points": [["'$(date +%s)'", 1]],
+            "type": "count",
+            "tags": [
+              "session_id:${{ steps.debug.outputs.session-id }}",
+              "branch:${{ steps.debug.outputs.git-branch }}",
+              "status:${{ steps.debug.outputs.session-status }}",
+              "repository:${{ github.repository }}"
+            ]
+          },
+          {
+            "metric": "claude.session.count",
+            "points": [["'$(date +%s)'", ${{ steps.debug.outputs.session-count }}]],
+            "type": "gauge",
+            "tags": [
+              "repository:${{ github.repository }}"
+            ]
+          }
+        ]
+      }'
+```
+
+---
+
+## CI/CD Integration
+
+### Automated Testing with Debug
+
+```yaml
+name: Test with Claude Debug
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Tests with Claude
+        run: |
+          # Claude helps fix failing tests
+          claude-code --task "Fix failing tests"
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: Debug Session
+        uses: ./.github/actions/claude-debug
+        id: debug
+
+      - name: Run Tests
+        id: tests
+        run: npm test
+
+      - name: Report Test Results
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const testsPassed = '${{ steps.tests.outcome }}' === 'success';
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## Test Results
+
+              ${testsPassed ? '✅' : '❌'} Tests ${testsPassed ? 'passed' : 'failed'}
+
+              **Claude Session**: \`${{ steps.debug.outputs.session-id }}\`
+              **Branch**: \`${{ steps.debug.outputs.git-branch }}\`
+              **Commit**: \`${{ steps.debug.outputs.git-commit }}\`
+              `
+            });
+```
+
+### Deployment with Debug Tracking
+
+```yaml
+name: Deploy with Debug Tracking
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pre-deployment Claude Check
+        run: |
+          claude-code --task "Verify deployment readiness"
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: Debug Pre-deployment
+        uses: ./.github/actions/claude-debug
+        id: pre-deploy-debug
+
+      - name: Deploy
+        id: deploy
+        run: |
+          # Your deployment script
+          ./deploy.sh
+
+      - name: Record Deployment
+        run: |
+          # Record deployment with Claude session info
+          curl -X POST https://api.example.com/deployments \
+            -H "Content-Type: application/json" \
+            -d '{
+              "commit": "${{ steps.pre-deploy-debug.outputs.git-commit }}",
+              "branch": "${{ steps.pre-deploy-debug.outputs.git-branch }}",
+              "claude_session": "${{ steps.pre-deploy-debug.outputs.session-id }}",
+              "status": "${{ steps.deploy.outcome }}",
+              "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
+            }'
+```
+
+---
+
+## Advanced Patterns
+
+### Conditional Debug Extraction
+
+```yaml
+- name: Debug with Conditional Log Extraction
+  uses: ./.github/actions/claude-debug
+  id: debug
+  with:
+    extract-logs: ${{ github.event_name == 'workflow_dispatch' }}
+
+- name: Upload Logs (Manual Runs Only)
+  if: github.event_name == 'workflow_dispatch'
+  uses: actions/upload-artifact@v4
+  with:
+    name: claude-logs-${{ steps.debug.outputs.session-id }}
+    path: ~/.claude/logs/
+```
+
+### Matrix Strategy with Debug
+
+```yaml
+jobs:
+  test-matrix:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        node: [18, 20]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Debug Environment
+        uses: ./.github/actions/claude-debug
+        id: debug
+
+      - name: Tag Results
+        run: |
+          echo "OS: ${{ matrix.os }}"
+          echo "Node: ${{ matrix.node }}"
+          echo "Session: ${{ steps.debug.outputs.session-id }}"
+```
+
+---
+
+## Troubleshooting Examples
+
+### Debug with Verbose Output
+
+```yaml
+- name: Debug with Full Output
+  uses: ./.github/actions/claude-debug
+  id: debug
+  with:
+    additional-flags: '--verbose --debug'
+    extract-logs: true
+
+- name: Show Full JSON
+  run: |
+    echo '${{ steps.debug.outputs.json-output }}' | jq '.'
+```
+
+### Retry on Failure
+
+```yaml
+- name: Debug with Retry
+  uses: nick-fields/retry@v2
+  with:
+    timeout_minutes: 5
+    max_attempts: 3
+    command: |
+      gh workflow run .github/actions/claude-debug
+```
+
+---
+
+For more examples, see the [main README](./README.md) and [example workflows](../../workflows/).

--- a/.github/actions/claude-debug/README.md
+++ b/.github/actions/claude-debug/README.md
@@ -1,0 +1,461 @@
+# Claude Code Debug Action
+
+A reusable GitHub Action for extracting debugging information from Claude Code CLI sessions. This action runs the Claude Code CLI with JSON output format to capture session metadata, git context, and diagnostic information.
+
+## Features
+
+- ✅ Extract current and previous session IDs
+- ✅ Capture Claude Code version information
+- ✅ Include git context (branch, commit, status)
+- ✅ Support for continuing previous sessions
+- ✅ Optional session log extraction
+- ✅ Full JSON output capture
+- ✅ GitHub Actions summary generation
+- ✅ Works with repository dispatch workflows
+- ✅ Designed for use after Claude Code automation actions
+
+## Usage
+
+### Basic Usage
+
+```yaml
+- name: Get Claude Code Debug Info
+  uses: ./.github/actions/claude-debug
+  id: debug
+
+- name: Display Session ID
+  run: echo "Session ID: ${{ steps.debug.outputs.session-id }}"
+```
+
+### With Repository Dispatch
+
+This action is designed to work seamlessly with repository dispatch events and external repositories:
+
+```yaml
+name: External Debug Workflow
+
+on:
+  repository_dispatch:
+    types: [debug-claude-session]
+
+jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Claude Code
+        run: |
+          # Install Claude Code CLI
+          npm install -g @anthropic/claude-code
+
+      - name: Run Claude Debug Action
+        uses: nsheaps/.ai/.github/actions/claude-debug@main
+        id: debug
+        with:
+          continue: true
+          extract-logs: true
+          claude-api-key: ${{ secrets.CLAUDE_API_KEY }}
+
+      - name: Post Results Back
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.client_payload.issue_number }}
+          body: |
+            ## Claude Code Debug Results
+            - **Session ID**: `${{ steps.debug.outputs.session-id }}`
+            - **Previous Session**: `${{ steps.debug.outputs.previous-session-id }}`
+            - **Branch**: `${{ steps.debug.outputs.git-branch }}`
+            - **Status**: `${{ steps.debug.outputs.session-status }}`
+```
+
+### After Claude Code Action
+
+Use this action to debug or verify Claude Code automation workflows:
+
+```yaml
+- name: Run Claude Code Automation
+  uses: some-org/claude-code-action@v1
+  with:
+    task: "Fix linting errors"
+    api-key: ${{ secrets.CLAUDE_API_KEY }}
+
+- name: Debug Claude Session
+  uses: ./.github/actions/claude-debug
+  id: debug
+  with:
+    continue: true  # Continue from previous Claude session
+    extract-logs: true
+
+- name: Check for Errors
+  if: steps.debug.outputs.error != ''
+  run: |
+    echo "Error detected: ${{ steps.debug.outputs.error }}"
+    exit 1
+```
+
+### Advanced Usage with Multiple Repositories
+
+For organizations managing multiple repositories with Claude Code:
+
+```yaml
+name: Multi-Repo Claude Debug
+
+on:
+  workflow_dispatch:
+    inputs:
+      target-repo:
+        description: 'Repository to debug'
+        required: true
+
+jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Target Repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.inputs.target-repo }}
+          token: ${{ secrets.ORG_PAT }}
+
+      - name: Debug Claude Session
+        uses: nsheaps/.ai/.github/actions/claude-debug@main
+        id: debug
+        with:
+          working-directory: .
+          continue: true
+          extract-logs: true
+
+      - name: Upload Debug Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-debug-${{ steps.debug.outputs.session-id }}
+          path: |
+            ${{ steps.debug.outputs.json-output }}
+          retention-days: 7
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `continue` | Whether to continue from previous session | No | `true` |
+| `working-directory` | Working directory for Claude Code | No | `.` |
+| `claude-api-key` | Claude API key (if not in environment) | No | - |
+| `additional-flags` | Additional flags to pass to claude-code CLI | No | `''` |
+| `extract-logs` | Whether to extract recent session logs | No | `false` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `session-id` | Current Claude Code session ID |
+| `previous-session-id` | Previous Claude Code session ID |
+| `working-directory` | Working directory used by Claude Code |
+| `git-branch` | Current git branch |
+| `git-status` | Git status (clean/dirty) |
+| `git-commit` | Current git commit SHA |
+| `session-status` | Status of the Claude Code session |
+| `session-count` | Number of recent sessions |
+| `claude-version` | Claude Code CLI version |
+| `json-output` | Full JSON output from claude-code CLI |
+| `error` | Error message if command failed |
+| `logs` | Recent session logs (if extract-logs is true) |
+
+## Environment Requirements
+
+This action requires:
+
+- **Claude Code CLI**: Must be installed and available in PATH
+- **jq** (optional but recommended): For detailed JSON parsing
+- **git**: For extracting repository context
+
+### Installing Claude Code CLI
+
+```yaml
+- name: Install Claude Code
+  run: npm install -g @anthropic/claude-code
+```
+
+Or use a container with Claude Code pre-installed:
+
+```yaml
+jobs:
+  debug:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/anthropic/claude-code:latest
+```
+
+## Use Cases
+
+### 1. Post-Automation Debugging
+
+After running Claude Code automation, capture session details for audit trails:
+
+```yaml
+- uses: ./.github/actions/claude-debug
+  id: post-debug
+
+- name: Save to Database
+  run: |
+    curl -X POST https://api.example.com/claude-sessions \
+      -H "Content-Type: application/json" \
+      -d '{
+        "session_id": "${{ steps.post-debug.outputs.session-id }}",
+        "commit": "${{ steps.post-debug.outputs.git-commit }}",
+        "branch": "${{ steps.post-debug.outputs.git-branch }}"
+      }'
+```
+
+### 2. Multi-Stage Workflows
+
+Chain multiple Claude Code operations and track session continuity:
+
+```yaml
+- name: Stage 1 - Code Generation
+  uses: some-org/claude-code-action@v1
+
+- name: Debug Stage 1
+  uses: ./.github/actions/claude-debug
+  id: stage1-debug
+
+- name: Stage 2 - Code Review
+  uses: some-org/claude-code-action@v1
+  with:
+    continue-from: ${{ steps.stage1-debug.outputs.session-id }}
+
+- name: Debug Stage 2
+  uses: ./.github/actions/claude-debug
+  id: stage2-debug
+```
+
+### 3. External Repository Monitoring
+
+Monitor Claude Code sessions across organization repositories:
+
+```yaml
+name: Claude Session Monitor
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'  # Every 6 hours
+
+jobs:
+  monitor:
+    strategy:
+      matrix:
+        repo: [repo1, repo2, repo3]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: my-org/${{ matrix.repo }}
+
+      - uses: nsheaps/.ai/.github/actions/claude-debug@main
+        id: debug
+
+      - name: Alert on Errors
+        if: steps.debug.outputs.error != ''
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {
+              "text": "Claude error in ${{ matrix.repo }}: ${{ steps.debug.outputs.error }}"
+            }
+```
+
+### 4. PR Comment Integration
+
+Add debug information as comments on pull requests:
+
+```yaml
+- name: Debug Claude Session
+  uses: ./.github/actions/claude-debug
+  id: debug
+
+- name: Comment on PR
+  uses: actions/github-script@v7
+  with:
+    script: |
+      github.rest.issues.createComment({
+        issue_number: context.issue.number,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        body: `## 🤖 Claude Code Debug Info
+
+        - **Session**: \`${{ steps.debug.outputs.session-id }}\`
+        - **Version**: \`${{ steps.debug.outputs.claude-version }}\`
+        - **Status**: ${{ steps.debug.outputs.session-status }}
+
+        <details>
+        <summary>Full JSON Output</summary>
+
+        \`\`\`json
+        ${{ steps.debug.outputs.json-output }}
+        \`\`\`
+        </details>`
+      })
+```
+
+## Troubleshooting
+
+### Claude Code Not Found
+
+```yaml
+# Add Claude Code installation step
+- name: Install Claude Code
+  run: npm install -g @anthropic/claude-code
+
+- name: Verify Installation
+  run: claude-code --version
+```
+
+### API Key Issues
+
+Ensure the Claude API key is set:
+
+```yaml
+- uses: ./.github/actions/claude-debug
+  with:
+    claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+Or set as environment variable:
+
+```yaml
+env:
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+### JSON Parsing Failures
+
+Install jq for reliable JSON parsing:
+
+```yaml
+- name: Install jq
+  run: sudo apt-get update && sudo apt-get install -y jq
+```
+
+### Output Too Large
+
+The action automatically truncates outputs larger than 65KB. For full logs, use the artifact upload feature:
+
+```yaml
+- uses: ./.github/actions/claude-debug
+  with:
+    extract-logs: true
+
+- uses: actions/upload-artifact@v4
+  with:
+    name: claude-logs
+    path: ~/.claude/logs/
+```
+
+## Security Considerations
+
+### API Key Handling
+
+- Always use GitHub Secrets for API keys
+- Never commit API keys in workflow files
+- Use environment-specific secrets for different deployments
+
+### Repository Dispatch
+
+When using with repository dispatch:
+
+- Validate webhook signatures
+- Use repository dispatch types for access control
+- Limit which repositories can trigger workflows
+
+```yaml
+on:
+  repository_dispatch:
+    types: [debug-claude-session]  # Specific type for access control
+
+jobs:
+  debug:
+    # Only allow from trusted repositories
+    if: github.event.client_payload.source_repo == 'trusted-org/trusted-repo'
+```
+
+### Log Extraction
+
+Be cautious when extracting logs with `extract-logs: true`:
+
+- Logs may contain sensitive information
+- Review logs before posting in public comments
+- Use private artifacts for sensitive debug data
+
+## Integration Examples
+
+### With Slack Notifications
+
+```yaml
+- uses: ./.github/actions/claude-debug
+  id: debug
+
+- uses: slackapi/slack-github-action@v1
+  with:
+    webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+    payload: |
+      {
+        "text": "Claude Session Complete",
+        "blocks": [
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "*Session ID*: `${{ steps.debug.outputs.session-id }}`\n*Branch*: `${{ steps.debug.outputs.git-branch }}`\n*Status*: ${{ steps.debug.outputs.session-status }}"
+            }
+          }
+        ]
+      }
+```
+
+### With DataDog Metrics
+
+```yaml
+- uses: ./.github/actions/claude-debug
+  id: debug
+
+- name: Send to DataDog
+  run: |
+    curl -X POST "https://api.datadoghq.com/api/v1/series" \
+      -H "DD-API-KEY: ${{ secrets.DD_API_KEY }}" \
+      -d '{
+        "series": [{
+          "metric": "claude.session.complete",
+          "points": [['$(date +%s)', 1]],
+          "tags": [
+            "session_id:${{ steps.debug.outputs.session-id }}",
+            "branch:${{ steps.debug.outputs.git-branch }}",
+            "status:${{ steps.debug.outputs.session-status }}"
+          ]
+        }]
+      }'
+```
+
+## Contributing
+
+Contributions welcome! Please:
+
+1. Test changes locally with `act` or GitHub Actions
+2. Update documentation for new inputs/outputs
+3. Add examples for new use cases
+4. Follow existing code style
+
+## Support
+
+- **Issues**: [GitHub Issues](https://github.com/nsheaps/.ai/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/nsheaps/.ai/discussions)
+- **Claude Code Docs**: [code.claude.com/docs](https://code.claude.com/docs)
+
+## Related Actions
+
+- [Claude Code Action](https://github.com/anthropics/claude-code-action) - Main Claude Code automation action
+- [Setup Claude Code](https://github.com/anthropics/setup-claude-code) - Install Claude Code CLI
+
+---
+
+**Part of the [Claude Code Plugin Marketplace](https://github.com/nsheaps/.ai)**

--- a/.github/actions/claude-debug/action.yml
+++ b/.github/actions/claude-debug/action.yml
@@ -1,0 +1,222 @@
+name: 'Claude Code Debug Info'
+description: 'Extract debugging information from Claude Code CLI sessions including session IDs, status, and workflow context'
+branding:
+  icon: 'info'
+  color: 'blue'
+
+inputs:
+  continue:
+    description: 'Whether to continue from previous session (default: true)'
+    required: false
+    default: 'true'
+  working-directory:
+    description: 'Working directory for Claude Code (defaults to repository root)'
+    required: false
+    default: '.'
+  claude-api-key:
+    description: 'Claude API key (if not set in environment)'
+    required: false
+  additional-flags:
+    description: 'Additional flags to pass to claude-code CLI'
+    required: false
+    default: ''
+  extract-logs:
+    description: 'Whether to extract and include recent session logs'
+    required: false
+    default: 'false'
+
+outputs:
+  session-id:
+    description: 'Current Claude Code session ID'
+    value: ${{ steps.debug.outputs.session-id }}
+  previous-session-id:
+    description: 'Previous Claude Code session ID'
+    value: ${{ steps.debug.outputs.previous-session-id }}
+  working-directory:
+    description: 'Working directory used by Claude Code'
+    value: ${{ steps.debug.outputs.working-directory }}
+  git-branch:
+    description: 'Current git branch'
+    value: ${{ steps.debug.outputs.git-branch }}
+  git-status:
+    description: 'Git status (clean/dirty)'
+    value: ${{ steps.debug.outputs.git-status }}
+  git-commit:
+    description: 'Current git commit SHA'
+    value: ${{ steps.debug.outputs.git-commit }}
+  session-status:
+    description: 'Status of the Claude Code session'
+    value: ${{ steps.debug.outputs.session-status }}
+  session-count:
+    description: 'Number of recent sessions'
+    value: ${{ steps.debug.outputs.session-count }}
+  claude-version:
+    description: 'Claude Code CLI version'
+    value: ${{ steps.debug.outputs.claude-version }}
+  json-output:
+    description: 'Full JSON output from claude-code CLI'
+    value: ${{ steps.debug.outputs.json-output }}
+  error:
+    description: 'Error message if command failed'
+    value: ${{ steps.debug.outputs.error }}
+  logs:
+    description: 'Recent session logs (if extract-logs is true)'
+    value: ${{ steps.debug.outputs.logs }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Extract Claude Code Debug Information
+      id: debug
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        ANTHROPIC_API_KEY: ${{ inputs.claude-api-key }}
+        CONTINUE_FLAG: ${{ inputs.continue }}
+        ADDITIONAL_FLAGS: ${{ inputs.additional-flags }}
+        EXTRACT_LOGS: ${{ inputs.extract-logs }}
+      run: |
+        set +e  # Don't exit on error, we want to capture it
+
+        echo "::group::Claude Code Debug Information"
+
+        # Function to safely set output
+        set_output() {
+          local name="$1"
+          local value="$2"
+          # Escape special characters and handle multiline
+          value="${value//'%'/'%25'}"
+          value="${value//$'\n'/'%0A'}"
+          value="${value//$'\r'/'%0D'}"
+          echo "${name}=${value}" >> "$GITHUB_OUTPUT"
+        }
+
+        # Get Claude Code version
+        echo "Getting Claude Code version..."
+        CLAUDE_VERSION=$(claude-code --version 2>&1 || echo "unknown")
+        set_output "claude-version" "$CLAUDE_VERSION"
+        echo "Claude Code version: $CLAUDE_VERSION"
+
+        # Get git information
+        echo "Gathering git information..."
+        GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+        GIT_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+        GIT_STATUS=$(git status --porcelain 2>/dev/null)
+        if [ -z "$GIT_STATUS" ]; then
+          GIT_STATUS_CLEAN="clean"
+        else
+          GIT_STATUS_CLEAN="dirty"
+        fi
+
+        set_output "git-branch" "$GIT_BRANCH"
+        set_output "git-commit" "$GIT_COMMIT"
+        set_output "git-status" "$GIT_STATUS_CLEAN"
+        set_output "working-directory" "$PWD"
+
+        echo "Git Branch: $GIT_BRANCH"
+        echo "Git Commit: $GIT_COMMIT"
+        echo "Git Status: $GIT_STATUS_CLEAN"
+
+        # Build claude-code command
+        CLAUDE_CMD="claude-code"
+
+        if [ "$CONTINUE_FLAG" = "true" ]; then
+          CLAUDE_CMD="$CLAUDE_CMD --continue"
+        fi
+
+        CLAUDE_CMD="$CLAUDE_CMD --output-format json"
+
+        if [ -n "$ADDITIONAL_FLAGS" ]; then
+          CLAUDE_CMD="$CLAUDE_CMD $ADDITIONAL_FLAGS"
+        fi
+
+        echo "Running: $CLAUDE_CMD"
+
+        # Run claude-code and capture output
+        JSON_OUTPUT=$(eval "$CLAUDE_CMD" 2>&1)
+        EXIT_CODE=$?
+
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "::warning::Claude Code command failed with exit code $EXIT_CODE"
+          set_output "error" "Exit code $EXIT_CODE: $JSON_OUTPUT"
+          set_output "session-status" "error"
+        else
+          set_output "session-status" "success"
+
+          # Try to parse JSON output
+          if command -v jq &> /dev/null; then
+            echo "Parsing JSON output with jq..."
+
+            # Extract session information
+            SESSION_ID=$(echo "$JSON_OUTPUT" | jq -r '.session.id // .sessionId // .current_session // "unknown"' 2>/dev/null)
+            PREV_SESSION_ID=$(echo "$JSON_OUTPUT" | jq -r '.session.previous // .previousSessionId // .previous_session // "unknown"' 2>/dev/null)
+            SESSION_COUNT=$(echo "$JSON_OUTPUT" | jq -r '.sessions | length // .session_count // 0' 2>/dev/null)
+
+            set_output "session-id" "$SESSION_ID"
+            set_output "previous-session-id" "$PREV_SESSION_ID"
+            set_output "session-count" "$SESSION_COUNT"
+
+            echo "Session ID: $SESSION_ID"
+            echo "Previous Session ID: $PREV_SESSION_ID"
+            echo "Session Count: $SESSION_COUNT"
+          else
+            echo "::warning::jq not found, skipping JSON parsing"
+            echo "::notice::Install jq in your workflow for detailed JSON parsing"
+
+            # Basic parsing without jq
+            SESSION_ID=$(echo "$JSON_OUTPUT" | grep -oP '"(?:session|sessionId)":\s*"\K[^"]+' | head -1 || echo "unknown")
+            set_output "session-id" "$SESSION_ID"
+            set_output "previous-session-id" "unknown"
+            set_output "session-count" "0"
+          fi
+        fi
+
+        # Store full JSON output (truncate if too large for GitHub Actions)
+        JSON_OUTPUT_LEN=${#JSON_OUTPUT}
+        if [ $JSON_OUTPUT_LEN -gt 65000 ]; then
+          echo "::warning::JSON output truncated (size: $JSON_OUTPUT_LEN bytes)"
+          JSON_OUTPUT="${JSON_OUTPUT:0:65000}... [TRUNCATED]"
+        fi
+        set_output "json-output" "$JSON_OUTPUT"
+
+        # Extract logs if requested
+        if [ "$EXTRACT_LOGS" = "true" ]; then
+          echo "Extracting recent session logs..."
+          CLAUDE_LOG_DIR="${HOME}/.claude/logs"
+
+          if [ -d "$CLAUDE_LOG_DIR" ]; then
+            RECENT_LOGS=$(find "$CLAUDE_LOG_DIR" -type f -name "*.log" -mtime -1 2>/dev/null | sort -r | head -3)
+
+            if [ -n "$RECENT_LOGS" ]; then
+              LOGS_CONTENT=""
+              while IFS= read -r log_file; do
+                LOGS_CONTENT="${LOGS_CONTENT}\n=== ${log_file} ===\n"
+                LOGS_CONTENT="${LOGS_CONTENT}$(tail -n 50 "$log_file" 2>/dev/null)"
+              done <<< "$RECENT_LOGS"
+
+              set_output "logs" "$LOGS_CONTENT"
+            else
+              set_output "logs" "No recent logs found"
+            fi
+          else
+            set_output "logs" "Log directory not found"
+          fi
+        fi
+
+        echo "::endgroup::"
+
+        # Create summary
+        echo "## Claude Code Debug Summary" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Property | Value |" >> "$GITHUB_STEP_SUMMARY"
+        echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Claude Version | \`$CLAUDE_VERSION\` |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Session Status | \`${session_status:-unknown}\` |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Session ID | \`${SESSION_ID:-unknown}\` |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Previous Session | \`${PREV_SESSION_ID:-unknown}\` |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Git Branch | \`$GIT_BRANCH\` |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Git Commit | \`$GIT_COMMIT\` |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Git Status | \`$GIT_STATUS_CLEAN\` |" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Working Directory | \`$PWD\` |" >> "$GITHUB_STEP_SUMMARY"
+
+        exit 0

--- a/.github/workflows/claude-debug-example.yml
+++ b/.github/workflows/claude-debug-example.yml
@@ -1,0 +1,282 @@
+name: Claude Debug Action Examples
+
+on:
+  workflow_dispatch:
+    inputs:
+      example:
+        description: 'Which example to run'
+        required: true
+        type: choice
+        options:
+          - basic
+          - with-logs
+          - repository-dispatch
+          - multi-stage
+
+jobs:
+  # Example 1: Basic Usage
+  basic-debug:
+    if: github.event.inputs.example == 'basic'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Claude Code CLI (Mock for demo)
+        run: |
+          echo "In production, install Claude Code CLI here"
+          echo "npm install -g @anthropic/claude-code"
+          # For demo purposes, create a mock script
+          mkdir -p /usr/local/bin
+          cat > /tmp/claude-code << 'EOF'
+          #!/bin/bash
+          if [[ "$*" == *"--version"* ]]; then
+            echo "claude-code version 1.0.0"
+          elif [[ "$*" == *"--output-format json"* ]]; then
+            cat << 'JSONEOF'
+          {
+            "session": {
+              "id": "session-abc123",
+              "previous": "session-xyz789"
+            },
+            "sessions": ["session-abc123", "session-xyz789", "session-def456"],
+            "status": "success"
+          }
+          JSONEOF
+          fi
+          EOF
+          chmod +x /tmp/claude-code
+          sudo mv /tmp/claude-code /usr/local/bin/claude-code
+
+      - name: Run Claude Debug Action
+        uses: ./.github/actions/claude-debug
+        id: debug
+
+      - name: Display Debug Information
+        run: |
+          echo "Session ID: ${{ steps.debug.outputs.session-id }}"
+          echo "Previous Session: ${{ steps.debug.outputs.previous-session-id }}"
+          echo "Git Branch: ${{ steps.debug.outputs.git-branch }}"
+          echo "Git Status: ${{ steps.debug.outputs.git-status }}"
+          echo "Claude Version: ${{ steps.debug.outputs.claude-version }}"
+
+      - name: Check Session Status
+        run: |
+          if [ "${{ steps.debug.outputs.session-status }}" != "success" ]; then
+            echo "Session failed with error: ${{ steps.debug.outputs.error }}"
+            exit 1
+          fi
+
+  # Example 2: With Log Extraction
+  debug-with-logs:
+    if: github.event.inputs.example == 'with-logs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Claude Code
+        run: |
+          # Mock setup (replace with actual installation)
+          mkdir -p ~/.claude/logs
+          echo "Sample log entry" > ~/.claude/logs/session-$(date +%s).log
+
+      - name: Run Debug with Logs
+        uses: ./.github/actions/claude-debug
+        id: debug
+        with:
+          continue: true
+          extract-logs: true
+
+      - name: Save Logs as Artifact
+        if: steps.debug.outputs.logs != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-session-logs
+          path: ~/.claude/logs/
+          retention-days: 7
+
+      - name: Post to PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## 🤖 Claude Debug Report
+
+              - **Session**: \`${{ steps.debug.outputs.session-id }}\`
+              - **Status**: ${{ steps.debug.outputs.session-status }}
+              - **Branch**: \`${{ steps.debug.outputs.git-branch }}\`
+              - **Commit**: \`${{ steps.debug.outputs.git-commit }}\`
+
+              Logs have been uploaded as workflow artifacts.`
+            })
+
+  # Example 3: Repository Dispatch Handler
+  repository-dispatch-handler:
+    if: github.event.inputs.example == 'repository-dispatch' || github.event_name == 'repository_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Debug Claude Session
+        uses: ./.github/actions/claude-debug
+        id: debug
+        with:
+          continue: true
+          claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: Send Results to External System
+        run: |
+          # Example: Post results to webhook
+          curl -X POST https://webhook.example.com/claude-debug \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.WEBHOOK_TOKEN }}" \
+            -d '{
+              "source": "${{ github.repository }}",
+              "session_id": "${{ steps.debug.outputs.session-id }}",
+              "previous_session": "${{ steps.debug.outputs.previous-session-id }}",
+              "branch": "${{ steps.debug.outputs.git-branch }}",
+              "commit": "${{ steps.debug.outputs.git-commit }}",
+              "status": "${{ steps.debug.outputs.session-status }}",
+              "triggered_by": "${{ github.event_name }}"
+            }'
+
+      - name: Comment on Source PR (if from external repo)
+        if: github.event.client_payload.issue_number
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            const [owner, repo] = '${{ github.event.client_payload.source_repo }}'.split('/');
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: ${{ github.event.client_payload.issue_number }},
+              body: `✅ Debug completed in external repository\n\n**Session ID**: \`${{ steps.debug.outputs.session-id }}\`\n**Status**: ${{ steps.debug.outputs.session-status }}`
+            });
+
+  # Example 4: Multi-Stage Workflow
+  multi-stage-claude:
+    if: github.event.inputs.example == 'multi-stage'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Stage 1 - Initial Analysis
+        id: stage1
+        run: |
+          echo "Running Claude Code for initial analysis..."
+          # Your Claude Code automation here
+
+      - name: Debug Stage 1
+        uses: ./.github/actions/claude-debug
+        id: debug1
+        with:
+          continue: false  # Fresh session
+
+      - name: Validate Stage 1
+        run: |
+          if [ "${{ steps.debug1.outputs.session-status }}" != "success" ]; then
+            echo "Stage 1 failed"
+            exit 1
+          fi
+
+      - name: Stage 2 - Apply Changes
+        run: |
+          echo "Running Claude Code with changes from Stage 1..."
+          echo "Previous session: ${{ steps.debug1.outputs.session-id }}"
+          # Your Claude Code automation here
+
+      - name: Debug Stage 2
+        uses: ./.github/actions/claude-debug
+        id: debug2
+        with:
+          continue: true  # Continue from Stage 1
+
+      - name: Verify Session Continuity
+        run: |
+          echo "Stage 1 Session: ${{ steps.debug1.outputs.session-id }}"
+          echo "Stage 2 Session: ${{ steps.debug2.outputs.session-id }}"
+          echo "Stage 2 Previous: ${{ steps.debug2.outputs.previous-session-id }}"
+
+          # Verify session chain
+          if [ "${{ steps.debug2.outputs.previous-session-id }}" == "${{ steps.debug1.outputs.session-id }}" ]; then
+            echo "✅ Session continuity verified"
+          else
+            echo "❌ Session continuity broken"
+            exit 1
+          fi
+
+      - name: Generate Summary
+        run: |
+          cat >> $GITHUB_STEP_SUMMARY << 'EOF'
+          ## Multi-Stage Claude Workflow Summary
+
+          ### Stage 1: Analysis
+          - **Session ID**: `${{ steps.debug1.outputs.session-id }}`
+          - **Status**: ${{ steps.debug1.outputs.session-status }}
+
+          ### Stage 2: Implementation
+          - **Session ID**: `${{ steps.debug2.outputs.session-id }}`
+          - **Previous Session**: `${{ steps.debug2.outputs.previous-session-id }}`
+          - **Status**: ${{ steps.debug2.outputs.session-status }}
+
+          ### Git Context
+          - **Branch**: `${{ steps.debug2.outputs.git-branch }}`
+          - **Commit**: `${{ steps.debug2.outputs.git-commit }}`
+          - **Status**: ${{ steps.debug2.outputs.git-status }}
+          EOF
+
+  # Example 5: Cross-Repository Debug
+  cross-repo-debug:
+    if: github.event.inputs.example == 'cross-repo'
+    strategy:
+      matrix:
+        repo:
+          - repo1
+          - repo2
+          - repo3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Target Repository
+        uses: actions/checkout@v4
+        with:
+          repository: my-org/${{ matrix.repo }}
+          token: ${{ secrets.ORG_PAT }}
+
+      - name: Debug Claude Session
+        uses: nsheaps/.ai/.github/actions/claude-debug@main
+        id: debug
+
+      - name: Aggregate Results
+        run: |
+          # Send results to central monitoring system
+          echo "Repository: ${{ matrix.repo }}"
+          echo "Session: ${{ steps.debug.outputs.session-id }}"
+          echo "Status: ${{ steps.debug.outputs.session-status }}"
+
+          # Example: Store in artifact for aggregation
+          mkdir -p debug-results
+          cat > debug-results/${{ matrix.repo }}.json << EOF
+          {
+            "repository": "${{ matrix.repo }}",
+            "session_id": "${{ steps.debug.outputs.session-id }}",
+            "status": "${{ steps.debug.outputs.session-status }}",
+            "branch": "${{ steps.debug.outputs.git-branch }}",
+            "commit": "${{ steps.debug.outputs.git-commit }}"
+          }
+          EOF
+
+      - name: Upload Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-results-${{ matrix.repo }}
+          path: debug-results/

--- a/.github/workflows/repository-dispatch-debug.yml
+++ b/.github/workflows/repository-dispatch-debug.yml
@@ -1,0 +1,225 @@
+name: Repository Dispatch Debug Handler
+
+# This workflow handles repository_dispatch events from external repositories
+# External repos can trigger this workflow to get Claude Code debug information
+
+on:
+  repository_dispatch:
+    types:
+      - claude-debug-request
+      - claude-session-info
+
+jobs:
+  handle-debug-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.ref || github.ref }}
+
+      - name: Validate Request
+        id: validate
+        run: |
+          # Validate the request comes from a trusted source
+          ALLOWED_REPOS="${{ vars.ALLOWED_DEBUG_REPOS }}"
+
+          SOURCE_REPO="${{ github.event.client_payload.source_repo }}"
+
+          if [ -z "$SOURCE_REPO" ]; then
+            echo "error=No source repository specified" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          # Check if source repo is in allowed list (if configured)
+          if [ -n "$ALLOWED_REPOS" ]; then
+            if ! echo "$ALLOWED_REPOS" | grep -q "$SOURCE_REPO"; then
+              echo "error=Repository $SOURCE_REPO not authorized" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+          fi
+
+          echo "source_repo=$SOURCE_REPO" >> $GITHUB_OUTPUT
+          echo "✅ Request validated from $SOURCE_REPO"
+
+      - name: Setup Environment
+        run: |
+          echo "Setting up Claude Code environment..."
+
+          # Install dependencies (customize based on your needs)
+          if [ -f package.json ]; then
+            npm install
+          fi
+
+          # Install jq for JSON parsing
+          sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Install Claude Code CLI
+        run: |
+          # Install Claude Code CLI
+          # Replace with actual installation method
+          echo "Installing Claude Code CLI..."
+
+          # Example: npm install -g @anthropic/claude-code
+          # For demo, create a mock
+          cat > /tmp/claude-code << 'EOF'
+          #!/bin/bash
+          if [[ "$*" == *"--version"* ]]; then
+            echo "claude-code version 1.2.3"
+          elif [[ "$*" == *"--output-format json"* ]]; then
+            cat << 'JSONEOF'
+          {
+            "session": {
+              "id": "sess_$(date +%s)",
+              "previous": "sess_$(( $(date +%s) - 3600 ))",
+              "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+              "status": "active"
+            },
+            "sessions": [],
+            "workspace": {
+              "path": "$(pwd)",
+              "files_changed": 0
+            },
+            "git": {
+              "branch": "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo main)",
+              "commit": "$(git rev-parse HEAD 2>/dev/null || echo unknown)",
+              "dirty": $(git diff --quiet 2>/dev/null && echo false || echo true)
+            }
+          }
+          JSONEOF
+          fi
+          EOF
+          chmod +x /tmp/claude-code
+          sudo mv /tmp/claude-code /usr/local/bin/claude-code
+
+      - name: Run Claude Debug Action
+        uses: ./.github/actions/claude-debug
+        id: debug
+        with:
+          continue: ${{ github.event.client_payload.continue || 'true' }}
+          extract-logs: ${{ github.event.client_payload.extract_logs || 'false' }}
+          working-directory: ${{ github.event.client_payload.working_directory || '.' }}
+          additional-flags: ${{ github.event.client_payload.additional_flags || '' }}
+          claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: Prepare Response Payload
+        id: response
+        run: |
+          # Create a comprehensive response payload
+          cat > /tmp/response.json << EOF
+          {
+            "request_id": "${{ github.event.client_payload.request_id }}",
+            "source_repo": "${{ steps.validate.outputs.source_repo }}",
+            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "debug_info": {
+              "session_id": "${{ steps.debug.outputs.session-id }}",
+              "previous_session_id": "${{ steps.debug.outputs.previous-session-id }}",
+              "session_status": "${{ steps.debug.outputs.session-status }}",
+              "session_count": "${{ steps.debug.outputs.session-count }}",
+              "claude_version": "${{ steps.debug.outputs.claude-version }}"
+            },
+            "git_context": {
+              "branch": "${{ steps.debug.outputs.git-branch }}",
+              "commit": "${{ steps.debug.outputs.git-commit }}",
+              "status": "${{ steps.debug.outputs.git-status }}",
+              "working_directory": "${{ steps.debug.outputs.working-directory }}"
+            },
+            "workflow": {
+              "run_id": "${{ github.run_id }}",
+              "run_number": "${{ github.run_number }}",
+              "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+          }
+          EOF
+
+          # Make it available for next steps
+          echo "response_file=/tmp/response.json" >> $GITHUB_OUTPUT
+
+          cat /tmp/response.json
+
+      - name: Post Response to Webhook
+        if: github.event.client_payload.webhook_url
+        run: |
+          curl -X POST "${{ github.event.client_payload.webhook_url }}" \
+            -H "Content-Type: application/json" \
+            -H "X-GitHub-Event: repository_dispatch" \
+            -H "X-Request-ID: ${{ github.event.client_payload.request_id }}" \
+            -d @${{ steps.response.outputs.response_file }}
+
+      - name: Comment on Source Issue/PR
+        if: github.event.client_payload.issue_number && github.event.client_payload.source_repo
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const response = JSON.parse(fs.readFileSync('${{ steps.response.outputs.response_file }}', 'utf8'));
+
+            const [owner, repo] = '${{ github.event.client_payload.source_repo }}'.split('/');
+
+            const body = `## 🤖 Claude Code Debug Information
+
+            **Session ID**: \`${response.debug_info.session_id}\`
+            **Status**: ${response.debug_info.session_status === 'success' ? '✅' : '❌'} ${response.debug_info.session_status}
+            **Claude Version**: \`${response.debug_info.claude_version}\`
+
+            ### Git Context
+            - **Branch**: \`${response.git_context.branch}\`
+            - **Commit**: \`${response.git_context.commit}\`
+            - **Status**: \`${response.git_context.status}\`
+
+            ### Session History
+            - **Previous Session**: \`${response.debug_info.previous_session_id}\`
+            - **Total Sessions**: ${response.debug_info.session_count}
+
+            <details>
+            <summary>Workflow Details</summary>
+
+            - **Run ID**: ${response.workflow.run_id}
+            - **Run URL**: ${response.workflow.run_url}
+            - **Timestamp**: ${response.timestamp}
+
+            </details>
+
+            ${ '${{ steps.debug.outputs.error }}' ? `
+            ### ⚠️ Errors
+            \`\`\`
+            ${{ steps.debug.outputs.error }}
+            \`\`\`
+            ` : '' }
+            `;
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: ${{ github.event.client_payload.issue_number }},
+              body
+            });
+
+      - name: Upload Debug Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-debug-${{ github.run_id }}
+          path: |
+            ${{ steps.response.outputs.response_file }}
+            ~/.claude/logs/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Notify on Failure
+        if: failure()
+        run: |
+          echo "Debug workflow failed"
+
+          # If webhook URL provided, send failure notification
+          if [ -n "${{ github.event.client_payload.webhook_url }}" ]; then
+            curl -X POST "${{ github.event.client_payload.webhook_url }}" \
+              -H "Content-Type: application/json" \
+              -d '{
+                "request_id": "${{ github.event.client_payload.request_id }}",
+                "status": "failed",
+                "error": "Debug workflow failed",
+                "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              }'
+          fi


### PR DESCRIPTION
Add comprehensive GitHub action for extracting Claude Code CLI debug information:

- Created .github/actions/claude-debug composite action
- Runs claude-code CLI with --continue and --output-format json
- Exports session IDs, git context, and diagnostic information
- Supports repository dispatch from external repos
- Includes optional log extraction
- Generates GitHub Actions summary

Features:
- Session tracking (current and previous session IDs)
- Git context (branch, commit, status)
- Claude version information
- Full JSON output capture
- Error handling and reporting
- Works with external repositories via repository dispatch

Documentation:
- Comprehensive README with usage examples
- EXAMPLES.md with real-world scenarios
- Example workflows for common use cases
- Repository dispatch handler workflow

Use cases:
- Post-automation debugging
- Multi-stage workflow tracking
- Cross-repository monitoring
- CI/CD integration
- External repository integration via repository dispatch