### PR TITLE
feat(agent-tab-titles): add plugin for tmux/iTerm2 tab titles per agent role

### DIFF
--- a/plugins/agent-tab-titles/.claude-plugin/plugin.json
+++ b/plugins/agent-tab-titles/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "agent-tab-titles",
+  "version": "0.1.0",
+  "description": "Set tmux/iTerm2 tab titles to agent roles in agent team sessions. Disables Claude Code's LLM-generated titles and uses SessionStart hook to set role-based names.",
+  "author": {
+    "name": "Nathan Heaps",
+    "email": "nsheaps@gmail.com",
+    "url": "https://github.com/nsheaps"
+  },
+  "homepage": "https://github.com/nsheaps/ai-mktpl/tree/main/plugins/agent-tab-titles",
+  "repository": "https://github.com/nsheaps/ai-mktpl",
+  "keywords": ["tmux", "iterm2", "tab-title", "agent-teams", "pane-title"]
+}

--- a/plugins/agent-tab-titles/.release-it.js
+++ b/plugins/agent-tab-titles/.release-it.js
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: "../../.release-it.base.json",
+  plugins: {
+    "@release-it/bumper": {
+      in: ".claude-plugin/plugin.json",
+      out: ".claude-plugin/plugin.json",
+    },
+  },
+};

--- a/plugins/agent-tab-titles/README.md
+++ b/plugins/agent-tab-titles/README.md
@@ -1,0 +1,52 @@
+# agent-tab-titles
+
+Set tmux/iTerm2 tab titles to agent roles in Claude Code agent team sessions.
+
+## What It Does
+
+1. **Disables LLM-generated titles**: Sets `CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1` so Claude Code doesn't overwrite tab titles with auto-generated topic summaries
+2. **Sets role-based tab titles**: On `SessionStart`, sets the tmux window name and pane title to the agent's name/role
+
+## How It Works
+
+### In tmux (including iTerm2 `-CC` control mode)
+
+- Uses `tmux rename-window` to set the tab title (iTerm2 tabs map to tmux windows in `-CC` mode)
+- Uses `tmux select-pane -T` to set the per-pane title
+- Disables `automatic-rename` so the title persists
+
+### Outside tmux
+
+- Uses OSC 0 escape sequence (`\033]0;title\007`) to set the native terminal title
+
+## Title Resolution
+
+The hook resolves the tab title using this priority:
+
+1. `CLAUDE_CODE_AGENT_NAME` env var (teammate display name, e.g., "Bugs B (software-eng)")
+2. `agent_type` from SessionStart hook input
+3. `CLAUDE_CODE_AGENT_TYPE` env var
+4. Falls back to "claude"
+
+## Prerequisites
+
+For best results in iTerm2 + tmux:
+
+```
+# ~/.tmux.conf
+set-option -g set-titles on
+set-option -g set-titles-string '#T'
+
+# Optional: show pane titles in split pane mode
+set-option -g pane-border-status top
+set-option -g pane-border-format " #{pane_index}: #{pane_title} "
+```
+
+To see per-pane titles: iTerm2 → Preferences → Appearance → Panes → "Show per-pane title bar with split panes"
+
+## References
+
+- [iTerm2 tmux Integration](https://iterm2.com/documentation-tmux-integration.html)
+- [Claude Code Agent Teams](https://code.claude.com/docs/en/agent-teams)
+- [Claude Code Hooks](https://code.claude.com/docs/en/hooks)
+- Research: Road Runner's tab title mechanism analysis (agent-team `.claude/tmp/iterm-tmux-tab-naming-research.md`)

--- a/plugins/agent-tab-titles/hooks/hooks.json
+++ b/plugins/agent-tab-titles/hooks/hooks.json
@@ -1,0 +1,20 @@
+{
+  "description": "Set tmux window/pane titles to agent role on session start. Disables Claude Code LLM-generated titles via env var.",
+  "env": {
+    "CLAUDE_CODE_DISABLE_TERMINAL_TITLE": "1"
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/set-tab-title.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/agent-tab-titles/hooks/scripts/set-tab-title.sh
+++ b/plugins/agent-tab-titles/hooks/scripts/set-tab-title.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# set-tab-title.sh — Set tmux window/pane title to agent name or role
+#
+# Uses CLAUDE_CODE_AGENT_NAME (teammate display name) if available,
+# falls back to CLAUDE_CODE_AGENT_TYPE, then to "claude".
+#
+# Works in tmux -CC (iTerm2 control mode) — each tmux window maps
+# to an iTerm2 tab, so rename-window sets the tab title.
+
+set -euo pipefail
+
+# Read hook input (SessionStart provides agent_type, session_id, etc.)
+INPUT=$(cat 2>/dev/null || echo '{}')
+HOOK_AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // empty' 2>/dev/null || true)
+
+# Priority: CLAUDE_CODE_AGENT_NAME > hook agent_type > CLAUDE_CODE_AGENT_TYPE > "claude"
+TITLE="${CLAUDE_CODE_AGENT_NAME:-${HOOK_AGENT_TYPE:-${CLAUDE_CODE_AGENT_TYPE:-claude}}}"
+
+# Skip if not in a tmux session
+if [ -z "${TMUX:-}" ]; then
+  # Not in tmux — use OSC 0 escape sequence for native terminal title
+  printf '\033]0;%s\007' "$TITLE"
+  exit 0
+fi
+
+# Set tmux window name (shows as iTerm2 tab title in -CC mode)
+tmux rename-window "$TITLE" 2>/dev/null || true
+
+# Set tmux pane title (shows in per-pane title bar if enabled)
+tmux select-pane -T "$TITLE" 2>/dev/null || true
+
+# Disable automatic rename so the title sticks
+tmux set-window-option automatic-rename off 2>/dev/null || true
+
+exit 0


### PR DESCRIPTION
## Summary

- Sets tmux window/pane titles to agent names on `SessionStart` hook
- Disables Claude Code's LLM-generated terminal titles via `CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1`
- Works in tmux -CC (iTerm2 control mode) and native terminals (via OSC 0 escape)
- Title resolution priority: `CLAUDE_CODE_AGENT_NAME` > hook `agent_type` > `CLAUDE_CODE_AGENT_TYPE` > "claude"

Resolves https://github.com/nsheaps/ai-mktpl/issues/179

## Files

- `plugins/agent-tab-titles/.claude-plugin/plugin.json` — plugin manifest
- `plugins/agent-tab-titles/hooks/hooks.json` — SessionStart hook + env config
- `plugins/agent-tab-titles/hooks/scripts/set-tab-title.sh` — title-setting script
- `plugins/agent-tab-titles/README.md` — documentation
- `plugins/agent-tab-titles/.release-it.js` — release config

## Test plan

- [ ] Install plugin: `claude plugin install "agent-tab-titles@nsheaps-claude-plugins"`
- [ ] Start a team session and verify tab titles show agent names
- [ ] Verify titles persist (automatic-rename disabled)
- [ ] Test outside tmux — verify OSC 0 fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)