### PR TITLE
feat(remote-config): add plugin to sync upstream Claude config repo

### DIFF
--- a/plugins/remote-config/.claude-plugin/plugin.json
+++ b/plugins/remote-config/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "remote-config",
+  "version": "0.1.0",
+  "description": "Sync upstream Claude config repo on session start. Pulls latest from a configured git repo to ~/.claude-remote/ and reports update status.",
+  "author": {
+    "name": "Nathan Heaps",
+    "email": "nsheaps@gmail.com",
+    "url": "https://github.com/nsheaps"
+  },
+  "homepage": "https://github.com/nsheaps/ai-mktpl/tree/main/plugins/remote-config",
+  "repository": "https://github.com/nsheaps/ai-mktpl",
+  "keywords": ["remote-config", "sync", "dotfiles", "claude-config"]
+}

--- a/plugins/remote-config/.release-it.js
+++ b/plugins/remote-config/.release-it.js
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: "../../.release-it.base.json",
+  plugins: {
+    "@release-it/bumper": {
+      in: ".claude-plugin/plugin.json",
+      out: ".claude-plugin/plugin.json",
+    },
+  },
+};

--- a/plugins/remote-config/README.md
+++ b/plugins/remote-config/README.md
@@ -1,0 +1,85 @@
+# remote-config
+
+Sync an upstream Claude config repo on session start.
+
+## What It Does
+
+On every `SessionStart`, pulls the latest from a configured git repo into `~/.claude-remote/`. Reports the update status so you know what version of your config is active.
+
+## Configuration
+
+Create `~/.claude/settings.remote-config.yaml`:
+
+```yaml
+# Required: URL of the upstream config repo
+upstream: https://github.com/nsheaps/.claude.git
+
+# Optional: show commit titles since last update (default: false)
+verbose: true
+```
+
+### Environment Variable Override
+
+Set `CLAUDE_REMOTE_UPSTREAM` to override the config file's `upstream` value:
+
+```bash
+export CLAUDE_REMOTE_UPSTREAM=https://github.com/nsheaps/.claude.git
+```
+
+## Behavior
+
+### On Session Start
+
+1. Reads config from `~/.claude/settings.remote-config.yaml` (or `CLAUDE_REMOTE_UPSTREAM` env var)
+2. If `~/.claude-remote/` doesn't exist: clones the repo
+3. If it exists: runs `git pull --ff-only`
+4. Reports status:
+
+**Clean update:**
+
+```
+[remote-config] Updated: abc1234 → v1.2.0 (def5678)
+[remote-config] Changes:                          # only if verbose: true
+  def5678 feat: add new agent definition
+  abc1234 fix: correct hook path
+```
+
+**Already up to date:**
+
+```
+[remote-config] Up to date: v1.2.0 (abc1234)
+```
+
+**Dirty repo (conflicts or uncommitted changes):**
+
+```
+[remote-config] Error: Cannot update ~/.claude-remote cleanly
+[remote-config] Suggest: cd ~/.claude-remote && git status
+[remote-config] Claude could fix this — reset to origin and re-pull
+```
+
+### Status Format
+
+- If HEAD is tagged: `tag (short-sha)` (e.g., `v1.2.0 (abc1234)`)
+- If not tagged: `short-sha` (e.g., `abc1234`)
+- If verbose: commit titles since last update, most recent last
+
+## Installation
+
+```bash
+claude plugin install "remote-config@nsheaps-claude-plugins" --scope user
+```
+
+Then create the config file:
+
+```bash
+cat > ~/.claude/settings.remote-config.yaml << 'EOF'
+upstream: https://github.com/nsheaps/.claude.git
+verbose: false
+EOF
+```
+
+## References
+
+- [Claude Code Plugins](https://code.claude.com/docs/en/plugins)
+- [Claude Code Hooks](https://code.claude.com/docs/en/hooks)

--- a/plugins/remote-config/hooks/hooks.json
+++ b/plugins/remote-config/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Sync upstream Claude config repo on session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/sync-remote.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/remote-config/hooks/scripts/sync-remote.sh
+++ b/plugins/remote-config/hooks/scripts/sync-remote.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# sync-remote.sh — Sync upstream Claude config repo on session start
+#
+# Reads config from ~/.claude/settings.remote-config.yaml (or env var).
+# Clones/pulls the upstream repo to ~/.claude-remote/.
+# Reports update status: tag + short sha, or just short sha.
+# If verbose: true, prints commit titles since last update.
+
+set -euo pipefail
+
+CONFIG_FILE="${CLAUDE_REMOTE_CONFIG:-$HOME/.claude/settings.remote-config.yaml}"
+REMOTE_DIR="$HOME/.claude-remote"
+
+# --- Config Reading ---
+
+# Read a YAML key (simple single-line values only)
+yaml_get() {
+  local file="$1" key="$2"
+  if command -v yq &>/dev/null; then
+    yq -r ".$key // empty" "$file" 2>/dev/null || true
+  else
+    # Fallback: grep-based for simple key: value pairs
+    grep -E "^${key}:" "$file" 2>/dev/null | sed "s/^${key}:[[:space:]]*//" | sed 's/^["'\'']//' | sed 's/["'\'']$//' || true
+  fi
+}
+
+# --- Load Config ---
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  # No config file — check env var
+  if [ -n "${CLAUDE_REMOTE_UPSTREAM:-}" ]; then
+    UPSTREAM_REPO="$CLAUDE_REMOTE_UPSTREAM"
+    VERBOSE="false"
+  else
+    # No config at all — silently exit (plugin not configured)
+    exit 0
+  fi
+else
+  UPSTREAM_REPO=$(yaml_get "$CONFIG_FILE" "upstream")
+  VERBOSE=$(yaml_get "$CONFIG_FILE" "verbose")
+
+  # Env var overrides config file
+  UPSTREAM_REPO="${CLAUDE_REMOTE_UPSTREAM:-$UPSTREAM_REPO}"
+  VERBOSE="${VERBOSE:-false}"
+fi
+
+if [ -z "$UPSTREAM_REPO" ]; then
+  echo "[remote-config] Error: No upstream repo configured" >&2
+  echo "[remote-config] Set 'upstream' in $CONFIG_FILE or CLAUDE_REMOTE_UPSTREAM env var" >&2
+  exit 0
+fi
+
+# --- Sync ---
+
+PREV_SHA=""
+
+if [ -d "$REMOTE_DIR/.git" ]; then
+  # Repo exists — pull latest
+  PREV_SHA=$(git -C "$REMOTE_DIR" rev-parse --short HEAD 2>/dev/null || true)
+
+  if ! git -C "$REMOTE_DIR" pull --ff-only --quiet 2>/dev/null; then
+    echo "[remote-config] Error: Cannot update $REMOTE_DIR cleanly" >&2
+    echo "[remote-config] Suggest: cd $REMOTE_DIR && git status" >&2
+    echo "[remote-config] Claude could fix this — reset to origin and re-pull" >&2
+    # Hook stdout is shown to user; they can decide
+    exit 0
+  fi
+else
+  # Fresh clone
+  if ! git clone --quiet "$UPSTREAM_REPO" "$REMOTE_DIR" 2>/dev/null; then
+    echo "[remote-config] Error: Failed to clone $UPSTREAM_REPO" >&2
+    echo "[remote-config] Check the upstream URL in $CONFIG_FILE" >&2
+    exit 0
+  fi
+  echo "[remote-config] Cloned $UPSTREAM_REPO → $REMOTE_DIR"
+fi
+
+# --- Status ---
+
+CURRENT_SHA=$(git -C "$REMOTE_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+# Check for tag at HEAD
+TAG=$(git -C "$REMOTE_DIR" describe --tags --exact-match HEAD 2>/dev/null || true)
+
+if [ -n "$TAG" ]; then
+  STATUS_LINE="$TAG ($CURRENT_SHA)"
+else
+  STATUS_LINE="$CURRENT_SHA"
+fi
+
+if [ -n "$PREV_SHA" ] && [ "$PREV_SHA" != "$CURRENT_SHA" ]; then
+  echo "[remote-config] Updated: $PREV_SHA → $STATUS_LINE"
+
+  # Verbose: show commit titles since last update
+  if [ "$VERBOSE" = "true" ]; then
+    echo "[remote-config] Changes:"
+    git -C "$REMOTE_DIR" log --oneline "${PREV_SHA}..HEAD" --reverse 2>/dev/null | while IFS= read -r line; do
+      echo "  $line"
+    done
+  fi
+elif [ -z "$PREV_SHA" ]; then
+  echo "[remote-config] Ready: $STATUS_LINE"
+else
+  # No changes
+  echo "[remote-config] Up to date: $STATUS_LINE"
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- SessionStart hook syncs upstream Claude config repo to `~/.claude-remote/`
- Config via `~/.claude/settings.remote-config.yaml` or `CLAUDE_REMOTE_UPSTREAM` env var
- Reports update status: tag + short sha (if tagged), else just short sha
- Verbose mode prints commit titles since last update (most recent last)
- Handles dirty repos gracefully with actionable error messages

## Files

- `plugins/remote-config/.claude-plugin/plugin.json` — plugin manifest
- `plugins/remote-config/hooks/hooks.json` — SessionStart hook config
- `plugins/remote-config/hooks/scripts/sync-remote.sh` — sync script
- `plugins/remote-config/README.md` — documentation
- `plugins/remote-config/.release-it.js` — release config

## Test plan

- [ ] Install plugin and create config file with valid upstream URL
- [ ] Start a new session — verify clone on first run
- [ ] Start another session — verify pull and "up to date" status
- [ ] Push a change upstream, start session — verify update with sha diff
- [ ] Tag a release upstream — verify tag appears in status
- [ ] Set `verbose: true` — verify commit titles are printed
- [ ] Make local changes in ~/.claude-remote — verify dirty repo error

🤖 Generated with [Claude Code](https://claude.com/claude-code)