### PR TITLE
fix: change empty matcher to wildcard in skill-required PreToolUse hook

### DIFF
--- a/plugins/skill-required/hooks/hooks.json
+++ b/plugins/skill-required/hooks/hooks.json
@@ -15,7 +15,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "",
+        "matcher": "*",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

- Fixed `"matcher": ""` → `"matcher": "*"` in the skill-required plugin's PreToolUse hook
- Empty string matcher matches nothing, so the enforcement check was never running
- This is a follow-up fix since ai-mktpl#187 was already merged with this bug on main

Fixes #186

## Test plan

- [ ] Install skill-required plugin and verify PreToolUse hook fires on tool calls
- [ ] Verify PostToolUse hook still correctly caches Skill reads (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>