### PR TITLE
fix: replace temp file logic with direct write in safe_write_settings

### DIFF
--- a/shared/lib/safe-settings-write.sh
+++ b/shared/lib/safe-settings-write.sh
@@ -7,7 +7,7 @@
 # on top of settings.json at runtime.
 #
 # Uses mkdir-based POSIX lock (portable, works on macOS where flock is absent),
-# mktemp for unique tmp files, jq output validation, and atomic rename.
+# jq output validation via variable capture, and direct file write.
 #
 # Usage:
 #   SETTINGS_FILE="$HOME/.claude/settings.local.json"
@@ -24,7 +24,6 @@
 safe_write_settings() {
   local jq_filter="$1"
   local lockdir="${SETTINGS_FILE}.lock"
-  local tmpfile
   local retries=0
 
   # Acquire lock via mkdir (atomic on POSIX)
@@ -55,19 +54,16 @@ safe_write_settings() {
     echo "{}" > "$SETTINGS_FILE"
   fi
 
-  # Create unique tmp file in same directory (for same-filesystem atomic rename)
-  tmpfile=$(mktemp "${SETTINGS_FILE}.XXXXXX")
-
   # Build jq args — pass $script if STATUSLINE_SCRIPT is set
   local jq_args=()
   if [ -n "${STATUSLINE_SCRIPT:-}" ]; then
     jq_args+=(--arg script "$STATUSLINE_SCRIPT")
   fi
 
-  # Run jq transformation to tmp file
+  # Run jq transformation into a variable (no temp file)
   # Note: ${jq_args[@]+"${jq_args[@]}"} avoids "unbound variable" on bash 3.2 (macOS default) with set -u
-  if ! jq ${jq_args[@]+"${jq_args[@]}"} "$jq_filter" "$SETTINGS_FILE" > "$tmpfile" 2>/dev/null; then
-    rm -f "$tmpfile"
+  local result
+  if ! result=$(jq ${jq_args[@]+"${jq_args[@]}"} "$jq_filter" "$SETTINGS_FILE" 2>/dev/null); then
     rmdir "$lockdir" 2>/dev/null || true
     trap - EXIT
     echo "WARNING: jq transformation failed, skipping update" >&2
@@ -75,16 +71,15 @@ safe_write_settings() {
   fi
 
   # Validate output is non-empty valid JSON
-  if [ ! -s "$tmpfile" ] || ! jq empty "$tmpfile" 2>/dev/null; then
-    rm -f "$tmpfile"
+  if [ -z "$result" ] || ! echo "$result" | jq empty 2>/dev/null; then
     rmdir "$lockdir" 2>/dev/null || true
     trap - EXIT
     echo "WARNING: jq produced invalid output, skipping update" >&2
     return 0
   fi
 
-  # Atomic rename (same filesystem guarantees atomicity)
-  mv "$tmpfile" "$SETTINGS_FILE"
+  # Write directly to the settings file (no temp file)
+  echo "$result" > "$SETTINGS_FILE"
 
   # Release lock
   rmdir "$lockdir" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Removed temp file + atomic rename pattern from `safe_write_settings` in `shared/lib/safe-settings-write.sh`
- Now captures jq output into a variable, validates it, then writes directly to the settings file
- The mkdir-based POSIX lock is preserved for concurrency safety
- Fixes the root cause of settings file blanking reported in #192

## What changed

| Before | After |
|--------|-------|
| `mktemp` creates temp file in same dir | jq output captured into `$result` variable |
| jq writes to temp file | Validation via `echo "$result" \| jq empty` |
| `mv` atomic rename to target | `echo "$result" > "$SETTINGS_FILE"` direct write |

## Affected plugins

All via symlinks to `shared/lib/safe-settings-write.sh`:
- `plugins/statusline/`
- `plugins/statusline-iterm/`
- `plugins/datadog-otel-setup/`

## Test plan

- [x] `bash -n` syntax check passes
- [x] Functional test: existing content preserved, new key added, no temp files created
- [ ] Verify statusline plugin configures correctly on session start
- [ ] Verify no `.XXXXXX` temp files left in `~/.claude/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)