### PR TITLE
Simplify safe-settings-write.sh by removing locking mechanism

### DIFF
--- a/.claude/rules/shared-libs.md
+++ b/.claude/rules/shared-libs.md
@@ -54,13 +54,13 @@ add_permission_to_allow "Bash(tool:*)" "user"          # user-level
 
 ### safe-settings-write.sh
 
-Atomic, concurrent-safe JSON settings writer using POSIX mkdir-based locking.
+Simple jq-based settings writer.
 
 ```bash
 SETTINGS_FILE="/path/to/settings.local.json"
 source "${CLAUDE_PLUGIN_ROOT}/lib/safe-settings-write.sh"
 
-safe_write_settings '.some.key = "value"'  # jq filter applied atomically
+safe_write_settings '.some.key = "value"'  # jq filter applied to file
 ```
 
 ## Adding a New Shared Library

--- a/shared/lib/safe-settings-write.sh
+++ b/shared/lib/safe-settings-write.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
-# safe-settings-write.sh — Atomic, concurrent-safe settings writer
+# safe-settings-write.sh — Simple jq-based settings writer
 #
 # Shared library for plugins that need to modify Claude Code settings.
 # IMPORTANT: Plugins should write to settings.local.json (not settings.json)
 # to avoid truncating user configuration. Claude Code merges settings.local.json
 # on top of settings.json at runtime.
-#
-# Uses mkdir-based POSIX lock (portable, works on macOS where flock is absent),
-# jq output validation via variable capture, and direct file write.
 #
 # Usage:
 #   SETTINGS_FILE="$HOME/.claude/settings.local.json"
@@ -20,51 +17,13 @@
 # Requires: jq, SETTINGS_FILE must be set before sourcing.
 # Note: Plugins symlink this file into their own lib/ directory.
 # Symlinked content is resolved and copied on plugin install.
-#
-# EXIT trap contract: safe_write_settings sets and clears an EXIT trap
-# internally for lock cleanup. Callers must not rely on their own EXIT
-# traps surviving a call to this function — any previously set EXIT trap
-# will be overwritten. Both success and error paths clear the trap via
-# `trap - EXIT` before returning, so subsequent caller traps set after
-# the call will work normally.
-#
-# Known limitation: The STATUSLINE_SCRIPT global variable is checked to
-# conditionally pass `--arg script "$STATUSLINE_SCRIPT"` to jq. This
-# couples the "shared" library to the statusline plugins' convention.
-# Current consumers (statusline, statusline-iterm) both use this pattern.
-# TODO: When a 3rd consumer appears, refactor to accept extra jq args as
-# function parameters instead (e.g., safe_write_settings '.key = $v' --arg v "val").
 
 safe_write_settings() {
   local jq_filter="$1"
-  local lockdir="${SETTINGS_FILE}.lock"
-  local retries=0
 
-  # Acquire lock via mkdir (atomic on POSIX)
-  while ! mkdir "$lockdir" 2>/dev/null; do
-    retries=$((retries + 1))
-    if [ "$retries" -ge 30 ]; then
-      # Stale lock detection: if lock is older than 10 seconds, remove it
-      if [ -d "$lockdir" ]; then
-        local lock_age
-        lock_age=$(( $(date +%s) - $(stat -f %m "$lockdir" 2>/dev/null || stat -c %Y "$lockdir" 2>/dev/null || echo "0") ))
-        if [ "$lock_age" -gt 10 ]; then
-          rmdir "$lockdir" 2>/dev/null || true
-          retries=0
-          continue
-        fi
-      fi
-      echo "WARNING: Could not acquire lock on settings.json after 3s, skipping update" >&2
-      return 0
-    fi
-    sleep 0.1
-  done
-
-  # Ensure lock is released on exit (even on error/signal)
-  trap 'rmdir "$lockdir" 2>/dev/null || true' EXIT
-
-  # Ensure settings file exists (inside lock to prevent race)
+  # Ensure settings file exists
   if [ ! -f "$SETTINGS_FILE" ]; then
+    mkdir -p "$(dirname "$SETTINGS_FILE")"
     echo "{}" > "$SETTINGS_FILE"
   fi
 
@@ -74,28 +33,17 @@ safe_write_settings() {
     jq_args+=(--arg script "$STATUSLINE_SCRIPT")
   fi
 
-  # Run jq transformation into a variable (no temp file)
-  # Note: ${jq_args[@]+"${jq_args[@]}"} avoids "unbound variable" on bash 3.2 (macOS default) with set -u
+  # Run jq and write result back in place via sponge pattern (variable capture)
   local result
   if ! result=$(jq ${jq_args[@]+"${jq_args[@]}"} "$jq_filter" "$SETTINGS_FILE" 2>/dev/null); then
-    rmdir "$lockdir" 2>/dev/null || true
-    trap - EXIT
     echo "WARNING: jq transformation failed, skipping update" >&2
     return 0
   fi
 
-  # Validate output is non-empty valid JSON
-  if [ -z "$result" ] || ! echo "$result" | jq empty 2>/dev/null; then
-    rmdir "$lockdir" 2>/dev/null || true
-    trap - EXIT
-    echo "WARNING: jq produced invalid output, skipping update" >&2
+  if [ -z "$result" ]; then
+    echo "WARNING: jq produced empty output, skipping update" >&2
     return 0
   fi
 
-  # Write directly to the settings file (no temp file)
   echo "$result" > "$SETTINGS_FILE"
-
-  # Release lock
-  rmdir "$lockdir" 2>/dev/null || true
-  trap - EXIT
 }


### PR DESCRIPTION
## What

Removed the POSIX mkdir-based locking mechanism from `safe-settings-write.sh`, simplifying the implementation to a basic jq-based settings writer. The function now directly reads, transforms, and writes settings without concurrent-access protection.

Key changes:
- Removed all lock acquisition/release logic (mkdir-based locking)
- Removed stale lock detection and retry logic
- Removed EXIT trap setup for lock cleanup
- Simplified jq output validation (removed full JSON validation, kept empty check)
- Updated documentation to reflect the simplified behavior
- Removed coupling to `STATUSLINE_SCRIPT` global variable from comments (though the code still supports it)

## Why

The locking mechanism added significant complexity to the shared library without clear evidence it was necessary. The simplified approach reduces maintenance burden and makes the code easier to understand and debug. If concurrent-safe writes become a requirement in the future, it can be re-evaluated with actual use cases.

## How

Stripped out all lock-related code paths while preserving the core jq transformation logic. The function now:
1. Ensures the settings file exists (creating parent directories if needed)
2. Runs the jq filter transformation
3. Validates the output is non-empty
4. Writes the result directly to the file

Updated documentation in both the script header and `shared-libs.md` to reflect the simplified behavior.

## Validation steps

- [ ] Verify settings file is created with `{}` if it doesn't exist
- [ ] Verify jq transformations are applied correctly to existing settings
- [ ] Verify parent directories are created if missing
- [ ] Verify warnings are printed on jq errors or empty output
- [ ] Verify the function returns 0 on success and on graceful failures

## Additional Context

This is a simplification of the shared library. The removal of locking means concurrent writes to the same settings file could potentially cause data loss, but this appears to be an acceptable trade-off given the current usage patterns.

https://claude.ai/code/session_01X9XbiTj7qF26foJWMfRK6A