### PR TITLE
feat: add stale issue labeling workflow

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -43,3 +43,12 @@
 - name: chore
   description: Maintenance, refactoring, cleanup tasks
   color: 'fef2c0'
+
+# Stale issue management
+- name: stale
+  description: Issue has not had recent activity
+  color: 'ededed'
+
+- name: daily-report
+  description: Automated daily report issue (auto-closed when stale)
+  color: 'd4c5f9'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,43 @@
+name: Stale Issues
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # daily at 6am UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      # Step 1: Label all stale issues, but never auto-close
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity.
+          stale-issue-label: stale
+          days-before-stale: 30
+          days-before-close: -1
+          # Disable PR staleness
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          exempt-issue-labels: status:in-progress,status:blocked,status:on-hold,priority:high
+          operations-per-run: 100
+
+      # Step 2: Close stale daily-report issues
+      - uses: actions/stale@v9
+        with:
+          only-issue-labels: daily-report
+          stale-issue-label: stale
+          close-issue-message: >
+            This stale daily-report issue has been automatically closed due to inactivity.
+          days-before-stale: 30
+          days-before-close: 7
+          # Disable PR staleness
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          exempt-issue-labels: status:in-progress,status:blocked,status:on-hold,priority:high
+          operations-per-run: 50


### PR DESCRIPTION
## Summary

- Adds a daily stale issue workflow (`.github/workflows/stale.yml`) using `actions/stale@v9`
- All issues inactive for 30 days get labeled `stale` (but are NOT auto-closed)
- Issues with the `daily-report` label that go stale ARE auto-closed after 7 additional days of inactivity
- Issues labeled `status:in-progress`, `status:blocked`, `status:on-hold`, or `priority:high` are exempt from staleness
- Adds `stale` and `daily-report` labels to `.github/labels.yaml`

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Manually trigger workflow via `workflow_dispatch` after merge
- [ ] Confirm stale labels are applied to old issues
- [ ] Confirm only `daily-report` issues get auto-closed

https://claude.ai/code/session_016wNMdnmGmtoA4qo6jLYePx