### PR TITLE
Use gh auth setup-git for authenticated git push in CD workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -138,6 +138,8 @@ jobs:
           skip_push: true
 
       - name: Push all changes together
+        env:
+          GH_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
-          git remote set-url origin "https://x-access-token:${{ steps.auth.outputs.token }}@github.com/${{ github.repository }}.git"
+          gh auth setup-git
           git push


### PR DESCRIPTION
## What

Updated the CD workflow's git push step to use GitHub CLI's `gh auth setup-git` command for authentication instead of relying on implicit git credentials.

## Why

The `gh auth setup-git` command properly configures git to use the GitHub token for authentication, ensuring that authenticated pushes work reliably in the CI/CD environment. This is more explicit and maintainable than relying on default credential handling.

## How

Modified the "Push all changes together" step in `.github/workflows/cd.yaml` to:
1. Pass the GitHub token via the `GH_TOKEN` environment variable (from the existing `steps.auth.outputs.token`)
2. Run `gh auth setup-git` to configure git authentication before pushing
3. Execute `git push` with proper authentication context

## Validation steps

- [ ] CD workflow runs successfully and pushes changes with proper authentication
- [ ] Existing tests pass

## Additional Context, Related PRs, Issues, Links

N/A

https://claude.ai/code/session_0189gHoRYFdoYF2gtzBB5JLM