### PR TITLE
chore: rename _FORCE_AUTOUPDATE_PLUGINS back to FORCE_AUTOUPDATE_PLUGINS

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "env": {
-    "_FORCE_AUTOUPDATE_PLUGINS": "true"
+    "FORCE_AUTOUPDATE_PLUGINS": "true"
   },
   "attribution": {
     "commit": "\nCo-Authored-By: Claude Code (${CLAUDE_PROJECT_DIR/$HOME/~}) <noreply@anthropic.com>"


### PR DESCRIPTION
Remove leading underscore from env var name in settings.

https://claude.ai/code/session_01G3Cg9ik43VwurTKiUVChcx