### PR TITLE
fix: run plugin SessionStart hooks after initial installation

### DIFF
--- a/.claude/hooks/session-start/01-install-plugins.sh
+++ b/.claude/hooks/session-start/01-install-plugins.sh
@@ -102,8 +102,8 @@ run_plugin_session_hooks() {
         return 0
     fi
 
-    # Get the most recently modified version directory
-    plugin_dir="$(ls -1td "${cache_base}/"*/ 2>/dev/null | head -1)"
+    # Get the latest version directory by semver sorting
+    plugin_dir="$(ls -1d "${cache_base}/"*/ 2>/dev/null | sort -V | tail -1)"
     if [ -z "$plugin_dir" ]; then
         echo "[01-install-plugins]   [hooks] No version dir in $cache_base, skipping"
         return 0
@@ -118,8 +118,8 @@ run_plugin_session_hooks() {
     fi
 
     # Extract SessionStart hook commands from hooks.json
-    local commands
-    commands=$(jq -r '
+    # Use `local commands=$(...)` so `local` swallows jq's exit code under set -e
+    local commands=$(jq -r '
         .hooks.SessionStart // [] | .[] |
         .hooks // [] | .[] |
         select(.type == "command") |


### PR DESCRIPTION
## Summary

- On fresh web sessions, plugins installed by `01-install-plugins.sh` never get their SessionStart hooks run because the SessionStart event fires before plugins exist
- After installing each plugin, discovers and executes their SessionStart hooks from `hooks/hooks.json` with `CLAUDE_PLUGIN_ROOT` set correctly
- Redirects plugin hook stdout to stderr to prevent `hook_respond` JSON from corrupting the parent hook's output

## Test plan

- [x] Verified in live web session: mise, git-spice, and plugin-dev plugins all installed and hooks ran successfully
- [ ] Test on a completely fresh web session to confirm end-to-end flow

Related to ongoing issue: Plugins set up in project settings.json are not installed and made available on initial session launch

https://claude.ai/code/session_01GCWZG1hSFdKFJKurDr9vvh