### PR TITLE
Add web-auto-approve plugin for Claude Code web sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -80,9 +80,6 @@
         ]
       }
     ],
-        ]
-      }
-    ],
     "SessionStart": [
       {
         "matcher": "",
@@ -131,7 +128,8 @@
     "mise@ai-mktpl": true,
     "scm-utils@ai-mktpl": false,
     "sequential-thinking@ai-mktpl": false,
-    "todo-sync@ai-mktpl": false
+    "todo-sync@ai-mktpl": false,
+    "web-auto-approve@ai-mktpl": true
   },
   "extraKnownMarketplaces": {
     "claude-plugins-official": {

--- a/plugins/web-auto-approve/.claude-plugin/plugin.json
+++ b/plugins/web-auto-approve/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "web-auto-approve",
+  "version": "0.1.0",
+  "description": "Auto-approve Edit, Write, and Bash permission requests in Claude Code web sessions to suppress interactive permission prompts",
+  "author": {
+    "name": "Nathan Heaps",
+    "email": "nsheaps@gmail.com",
+    "url": "https://github.com/nsheaps"
+  },
+  "homepage": "https://github.com/nsheaps/ai-mktpl/tree/main/plugins/web-auto-approve",
+  "repository": "https://github.com/nsheaps/ai-mktpl",
+  "keywords": [
+    "permissions",
+    "web-session",
+    "auto-approve",
+    "hooks",
+    "PermissionRequest"
+  ]
+}

--- a/plugins/web-auto-approve/README.md
+++ b/plugins/web-auto-approve/README.md
@@ -1,0 +1,22 @@
+# web-auto-approve
+
+Auto-approve `Edit`, `Write`, and `Bash` permission requests in Claude Code web sessions.
+
+## Why
+
+Since Claude Code v2.1.78, writes to protected directories (`.git`, `.claude`, `.vscode`, `.idea`) prompt for confirmation even with `bypassPermissions` enabled. In web sessions there is no interactive user to approve these prompts, so they block the agent.
+
+This plugin uses a `PermissionRequest` hook to automatically approve these tool calls when `CLAUDE_CODE_REMOTE` is set (i.e., running in a web session). Local CLI sessions are unaffected and still receive normal permission prompts.
+
+## How it works
+
+The `PermissionRequest` hook fires after permission rules evaluate but before the user dialog appears. When running in a web session, it emits an `allow` decision for `Edit`, `Write`, and `Bash` tool calls.
+
+## TODO
+
+- [ ] Test whether the plugin's PermissionRequest hooks are picked up fast enough at session start to replace the inline hooks in `.claude/settings.json`. If so, remove the duplicate inline `PermissionRequest` hooks from settings.json. The concern is that plugin hooks may not be registered before the first permission prompt fires. See #261.
+
+## Related
+
+- [#261](https://github.com/nsheaps/ai-mktpl/issues/261) - Repeated permissions issues since claude-code CLI update
+- [anthropics/claude-code#36044](https://github.com/anthropics/claude-code/issues/36044)

--- a/plugins/web-auto-approve/hooks/hooks.json
+++ b/plugins/web-auto-approve/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Auto-approve Edit/Write/Bash permission requests in web sessions",
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "matcher": "Edit|Write|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$CLAUDE_CODE_REMOTE\" ] && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PermissionRequest\",\"decision\":{\"behavior\":\"allow\"}}}' || true",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What

Added a new `web-auto-approve` plugin that automatically approves `Edit`, `Write`, and `Bash` permission requests in Claude Code web sessions. The plugin uses a `PermissionRequest` hook to emit allow decisions when `CLAUDE_CODE_REMOTE` is set, preventing permission prompts from blocking the agent in web environments.

Also fixed a malformed JSON structure in `.claude/settings.json` (duplicate closing brackets) and enabled the new plugin in the settings.

## Why

Since Claude Code v2.1.78, writes to protected directories (`.git`, `.claude`, `.vscode`, `.idea`) prompt for confirmation even with `bypassPermissions` enabled. In web sessions there is no interactive user to approve these prompts, causing the agent to block. This plugin solves that by automatically approving these permission requests in web environments while leaving local CLI sessions unaffected.

## How

- Created a new plugin with a `PermissionRequest` hook that checks for the `CLAUDE_CODE_REMOTE` environment variable
- When running in a web session (CLAUDE_CODE_REMOTE is set), the hook emits an `allow` decision for Edit, Write, and Bash tool calls
- Local CLI sessions are unaffected and continue to receive normal permission prompts
- Enabled the plugin in `.claude/settings.json`
- Fixed malformed JSON in settings file (removed duplicate closing brackets)

## Validation steps

- [ ] Plugin loads successfully in Claude Code web sessions
- [ ] Permission requests for Edit, Write, and Bash are auto-approved when `CLAUDE_CODE_REMOTE` is set
- [ ] Local CLI sessions still show permission prompts as expected
- [ ] Settings file JSON is valid

## Additional Context, Related PRs, Issues, Links

- [#261](https://github.com/nsheaps/ai-mktpl/issues/261) - Repeated permissions issues since claude-code CLI update
- [anthropics/claude-code#36044](https://github.com/anthropics/claude-code/issues/36044)

**Note:** There is a TODO to verify whether plugin hooks are registered fast enough at session start to replace the inline hooks in `.claude/settings.json`. If confirmed, the duplicate inline `PermissionRequest` hooks can be removed from settings.json.

https://claude.ai/code/session_01ATwZwJFG2rdrri4RJmTZei