### PR TITLE
fix: output plain text instead of JSON from session hooks

### DIFF
--- a/.claude/rules/shared-libs.md
+++ b/.claude/rules/shared-libs.md
@@ -56,22 +56,22 @@ add_permission_to_allow "Bash(tool:*)" "user"          # user-level
 
 ### hook-logging.sh
 
-Hook logging with structured JSON output. Messages are printed to stderr (user sees via Ctrl+O) and accumulated for JSON output on stdout (user sees via `systemMessage`, agent sees via `additionalContext`). On failure, a structured error block is also printed to stderr.
+Hook logging with human-readable output. Messages are printed to stderr (user sees via Ctrl+O) and accumulated for plain text output on stdout (user sees via `systemMessage`, agent sees via `additionalContext`). On failure, a structured error block is also printed to stderr.
 
 ```bash
 PLUGIN_NAME="my-plugin"  # MUST be set before sourcing
 source "${CLAUDE_PLUGIN_ROOT}/lib/hook-logging.sh"
 
-hook_log "Installing tool v1.2.3"              # stderr + accumulate for JSON
+hook_log "Installing tool v1.2.3"              # stderr + accumulate for stdout
 hook_log_always "Tool v1.2.3 ready"            # alias for hook_log
 hook_log_step "download" "Downloading binary"  # start a named step
 hook_fail "curl" "404 not found" "Check URL"   # structured error to stderr (returns 0)
 hook_run my_main_function                      # wrap function, auto-fail on non-zero exit
 hook_log_cleanup                               # remove log file on success
-hook_respond                                   # MUST be last — outputs JSON to stdout
+hook_respond                                   # MUST be last — outputs plain text to stdout
 ```
 
-**IMPORTANT:** `hook_respond` MUST be called exactly once, as the last thing before exit. It outputs accumulated messages as JSON with both `systemMessage` (user sees) and `additionalContext` (agent sees). Hooks MUST always exit 0.
+**IMPORTANT:** `hook_respond` MUST be called exactly once, as the last thing before exit. It outputs accumulated messages as plain text to stdout. Hooks MUST always exit 0.
 
 On failure, `hook_fail` prints:
 

--- a/shared/lib/hook-logging.sh
+++ b/shared/lib/hook-logging.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# hook-logging.sh — Shared library for hook logging with structured JSON output
+# hook-logging.sh — Shared library for hook logging with human-readable output
 #
-# All hooks output structured JSON to stdout (the only channel Claude Code
-# processes for both user-visible systemMessage and agent-visible
-# additionalContext). Human-readable messages also go to stderr for
-# Ctrl+O verbose mode and log file diagnostics.
+# All hooks output plain text to stdout (shown to the user as systemMessage
+# and provided to the agent as additionalContext). Human-readable messages
+# also go to stderr for Ctrl+O verbose mode and log file diagnostics.
 #
 # Usage:
 #   PLUGIN_NAME="my-plugin"                     # Required: set before sourcing
@@ -126,31 +125,16 @@ hook_fail() {
 
 # --- Response helper ---
 
-# Output accumulated messages as structured JSON to stdout.
+# Output accumulated messages as plain text to stdout.
 # MUST be called exactly once as the last thing before exit.
-# Outputs JSON with both systemMessage (user sees) and additionalContext (agent sees).
+# Stdout is shown to the user as systemMessage and provided to the agent as additionalContext.
 hook_respond() {
-  local combined=""
   if [ -s "$_HOOK_MSG_FILE" ]; then
-    combined=$(cat "$_HOOK_MSG_FILE")
+    cat "$_HOOK_MSG_FILE"
   fi
 
   # Clean up message file
   rm -f "$_HOOK_MSG_FILE" 2>/dev/null || true
-
-  if [ -n "$combined" ]; then
-    if command -v jq &>/dev/null; then
-      jq -n --arg msg "$combined" \
-        '{additionalContext: $msg, systemMessage: $msg}'
-    else
-      # Fallback: escape for JSON manually
-      local escaped
-      escaped=$(printf '%s' "$combined" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g' | sed ':a;N;$!ba;s/\n/\\n/g')
-      echo "{\"additionalContext\":\"${escaped}\",\"systemMessage\":\"${escaped}\"}"
-    fi
-  else
-    echo '{}'
-  fi
 }
 
 # --- Execution wrapper ---


### PR DESCRIPTION
## Summary
- Changed `hook_respond` in `shared/lib/hook-logging.sh` to output plain text instead of wrapping messages in a JSON object with `systemMessage` and `additionalContext` keys
- All 9 plugins symlink to this shared file so they all get the change automatically
- Updated documentation in `.claude/rules/shared-libs.md` to reflect the new behavior

## Test plan
- [ ] Verify session start hooks output is human-readable plain text (not JSON)
- [ ] Verify `hook_fail` error output on stderr is unchanged
- [ ] Confirm plugins using `hook_respond` still work correctly

https://claude.ai/code/session_01U8jwiUs9V5V9GtshCiKstW