### PR TITLE
fix: improve hook output for mise failures and git-spice logging

### DIFF
--- a/plugins/git-spice/hooks/scripts/check-gs-stack-status.sh
+++ b/plugins/git-spice/hooks/scripts/check-gs-stack-status.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
 # Check if gs-stack-status is installed and print install instructions if not
 
-# shellcheck source=../../lib/hook-output.sh
-source "${CLAUDE_PLUGIN_ROOT}/lib/hook-output.sh"
+PLUGIN_NAME="git-spice"
+# shellcheck source=../../lib/hook-logging.sh
+source "${CLAUDE_PLUGIN_ROOT}/lib/hook-logging.sh"
 
 if ! command -v gs-stack-status &>/dev/null; then
-  hook_msg "git-spice: gs-stack-status is not installed. Install it with:
-  brew install nsheaps/devsetup/gs-stack-status
-
-gs-stack-status provides a terminal dashboard for git-spice stacked branch workflows."
+  hook_log "gs-stack-status is not installed. Install it with:"
+  hook_log "  brew install nsheaps/devsetup/gs-stack-status"
+  hook_log ""
+  hook_log "gs-stack-status provides a terminal dashboard for git-spice stacked branch workflows."
 else
-  hook_msg "git-spice: gs-stack-status available"
+  hook_log "gs-stack-status available"
 fi
+
+hook_respond

--- a/plugins/git-spice/lib/hook-logging.sh
+++ b/plugins/git-spice/lib/hook-logging.sh
@@ -1,0 +1,1 @@
+../../../shared/lib/hook-logging.sh

--- a/plugins/mise/hooks/scripts/install-mise.sh
+++ b/plugins/mise/hooks/scripts/install-mise.sh
@@ -117,9 +117,16 @@ do_setup() {
   # Auto-install tools
   if [ "$auto_install_tools" = "true" ] && [ -f "${CLAUDE_PROJECT_DIR:-.}/mise.toml" ]; then
     hook_log_step "install-tools" "Installing tools from mise.toml"
-    if ! (cd "${CLAUDE_PROJECT_DIR:-.}" && GITHUB_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}" "$mise_bin" install -y); then
+    local install_output
+    install_output="$(cd "${CLAUDE_PROJECT_DIR:-.}" && GITHUB_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}" "$mise_bin" install -y 2>&1)" || {
       hook_log "mise install exited non-zero (partial failure). Tools that installed are still available."
-    fi
+      if [ -n "$install_output" ]; then
+        hook_log "mise install output:"
+        while IFS= read -r line; do
+          hook_log "  $line"
+        done <<< "$install_output"
+      fi
+    }
   fi
 }
 


### PR DESCRIPTION
## Summary
- **mise hook**: Capture and print actual `mise install` error output when it exits non-zero, so users/agents see what failed instead of just "partial failure"
- **git-spice hook**: Migrate `check-gs-stack-status` from `hook-output.sh` (JSON) to `hook-logging.sh` (plaintext) to match shared logging infra
- Whitespace formatting fix in `.claude/settings.json`

Relates to #261

## Test plan
- [ ] Verify mise hook shows actual error output when a tool fails to install
- [ ] Verify git-spice hook outputs plaintext (not JSON) on session start
- [ ] CI passes

https://claude.ai/code/session_01DcyvxfFTpxmtrDhTabjebJ