### PR TITLE
Use relative directory path for ai-mktpl marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -139,8 +139,8 @@
     },
     "ai-mktpl": {
       "source": {
-        "source": "github",
-        "repo": "nsheaps/ai-mktpl"
+        "source": "directory",
+        "path": "."
       }
     }
   }


### PR DESCRIPTION
## Summary
- Changed `extraKnownMarketplaces` for `ai-mktpl` from GitHub source to local directory source with relative path `"."`
- When working in the marketplace repo itself, this ensures local changes are picked up immediately during development rather than fetching from GitHub

## Test plan
- [ ] Verify plugins from ai-mktpl marketplace still load in a new session
- [ ] Verify local plugin changes are reflected without needing a git push

https://claude.ai/code/session_015JsjRNmusYjT5mTAdNdqte