### PR TITLE
fix: revert extraKnownMarketplaces to github source

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -139,8 +139,8 @@
     },
     "ai-mktpl": {
       "source": {
-        "source": "directory",
-        "path": "."
+        "source": "github",
+        "repo": "nsheaps/ai-mktpl"
       }
     }
   }


### PR DESCRIPTION
## Summary

- Reverts b08c3b6 which changed the `ai-mktpl` entry in `extraKnownMarketplaces` from a GitHub source to a relative directory path (`"source": "directory", "path": "."`)
- The directory source broke marketplace resolution in other sessions/projects that aren't inside the ai-mktpl repo directory

## Test plan

- [ ] Verify marketplace resolution works in other repos that reference ai-mktpl plugins
- [ ] Confirm `extraKnownMarketplaces` loads correctly from the github source

https://claude.ai/code/session_01JxxsQyKPqCRZuGvPT5ck4g