### PR TITLE
fix: prevent mise activation from polluting every bash command

### DIFF
--- a/.claude/hooks/post-tool-use/lint-written-file.sh
+++ b/.claude/hooks/post-tool-use/lint-written-file.sh
@@ -23,6 +23,18 @@ if [[ -z "$FILE_PATH" ]]; then
     exit 0
 fi
 
+# Only lint files within this project (ai-mktpl) — other repos won't have
+# the mise lint task and `mise run lint` would fail with "no tasks defined"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+case "$FILE_PATH" in
+    "$PROJECT_DIR"/*)
+        ;; # File is within project, continue
+    *)
+        exit 0 # File is outside project, skip
+        ;;
+esac
+
 # Only lint files that prettier can handle
 case "$FILE_PATH" in
     *.json|*.yaml|*.yml|*.md|*.js|*.ts|*.jsx|*.tsx|*.css|*.html)

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -28,8 +28,11 @@ name: cd
         type: string
 
 concurrency:
-  group: cd-${{ github.ref }}
-  cancel-in-progress: true
+  # On push to main, share concurrency group with CI to prevent races where
+  # both CI (lint auto-fix) and CD (version bump) try to push commits
+  # simultaneously. On PRs, use a separate group since CD only previews.
+  group: ${{ github.ref == 'refs/heads/main' && 'ci-cd-main' || format('cd-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # For PRs: Preview version bumps only (no commits)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,11 @@ name: ci
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # On push to main, share concurrency group with CD to prevent races where
+  # both CI (lint auto-fix) and CD (version bump) try to push commits
+  # simultaneously. On PRs, use a separate group.
+  group: ${{ github.ref == 'refs/heads/main' && 'ci-cd-main' || format('ci-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Fail if plugin.json or marketplace.json were manually changed in a PR

--- a/plugins/mise/hooks/scripts/install-mise.sh
+++ b/plugins/mise/hooks/scripts/install-mise.sh
@@ -83,11 +83,27 @@ do_setup() {
   tool_ensure_path "$INSTALL_DIR"
 
   # Activate mise in the current shell AND persist to CLAUDE_ENV_FILE
+  #
+  # IMPORTANT: We use `mise env -s bash` instead of `mise activate bash` for
+  # CLAUDE_ENV_FILE. `mise activate bash` installs a PROMPT_COMMAND hook that
+  # calls `eval "$(mise hook-env -s bash)"` on EVERY bash command. This causes
+  # problems because:
+  #   1. mise hook-env outputs errors to stderr (and sometimes stdout) when
+  #      mise.toml is not trusted, polluting every command's output
+  #   2. mise hook-env can output warnings (rate limits, missing tools) to
+  #      stdout, which get `eval`'d as bash commands causing "command not found"
+  #   3. The activation also overrides cd/pushd/popd to call _mise_hook on
+  #      every directory change, compounding the above issues
+  #
+  # `mise env -s bash` just outputs static `export` statements for the current
+  # tool versions — no hooks, no eval loops, no side effects.
   hook_log_step "activate-mise" "Activating mise in shell"
   eval "$("$mise_bin" activate bash)" 2>/dev/null || true
   if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-    echo 'eval "$('"$mise_bin"' activate bash)"' >> "$CLAUDE_ENV_FILE"
-    hook_log "Persisted mise activation to CLAUDE_ENV_FILE"
+    # Use `mise env` for persistence — it only exports PATH and tool vars,
+    # no hooks or eval loops that run on every command
+    echo 'eval "$('"$mise_bin"' env -s bash 2>/dev/null)"' >> "$CLAUDE_ENV_FILE"
+    hook_log "Persisted mise env to CLAUDE_ENV_FILE (using mise env, not activate)"
   fi
 
   # Auto-trust: trust mise config files in project dir and any git worktrees


### PR DESCRIPTION
## Summary

- **mise plugin**: Replace `eval "$(mise activate bash)"` with `eval "$(mise env -s bash 2>/dev/null)"` in CLAUDE_ENV_FILE. The `activate` command installs PROMPT_COMMAND hooks that run `eval "$(mise hook-env)"` on every bash command, causing "command not found" errors when mise.toml is untrusted or tools can't be resolved. `mise env` outputs only static `export` statements — no hooks, no eval loops.
- **lint-written-file.sh**: Guard against running `mise run lint` on files outside the ai-mktpl project directory. In multi-repo sessions, the hook was firing for files in other repos that don't have mise lint tasks, causing "no tasks defined" errors.
- **CI/CD race condition**: CI and CD workflows on push to main now share a concurrency group (`ci-cd-main`) so they can't push commits simultaneously.

## Test plan

- [ ] Verify no "Checking: command not found" or "mise ERROR" on every bash command
- [ ] Verify `mise env -s bash` correctly sets PATH for tools
- [ ] Verify lint hook only fires for files within ai-mktpl directory
- [ ] Verify CI and CD don't race on push to main

https://claude.ai/code/session_01Bd254H4YX3JGV1AWnfHM61