### PR TITLE
Fix GitHub plugin context for web session proxy

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -280,7 +280,7 @@
     {
       "name": "github",
       "description": "GitHub CLI installation, authentication, and workflow skill for Claude Code sessions. Consolidates gh-tool and github-auth-skill into a single plugin.",
-      "version": "0.1.15",
+      "version": "0.3.0",
       "author": {
         "name": "Nathan Heaps"
       },
@@ -299,11 +299,7 @@
         "issues",
         "session-start",
         "web-session",
-        "auto-install",
-        "pr-feedback",
-        "code-review",
-        "ci-failures",
-        "review-comments"
+        "auto-install"
       ]
     },
     {
@@ -569,7 +565,7 @@
     {
       "name": "scm-utils",
       "description": "Source control management utilities for improving interactions with branches and PRs, both locally and in CI environments",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "author": {
         "name": "Nathan Heaps"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -214,7 +214,7 @@
     {
       "name": "github",
       "description": "GitHub CLI installation, authentication, and workflow skill for Claude Code sessions. Consolidates gh-tool and github-auth-skill into a single plugin.",
-      "version": "0.1.13",
+      "version": "0.3.0",
       "author": {
         "name": "Nathan Heaps"
       },
@@ -454,7 +454,7 @@
     {
       "name": "scm-utils",
       "description": "Source control management utilities for improving interactions with branches and PRs, both locally and in CI environments",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "author": {
         "name": "Nathan Heaps"
       },

--- a/.claude/rules/auto-pr-management.md
+++ b/.claude/rules/auto-pr-management.md
@@ -25,9 +25,9 @@ Update the PR description **after every push** to reflect the current state of c
 
 ## How to Authenticate
 
-Use the `GH_TOKEN` environment variable with the `gh` CLI. Since the git remote in web sessions is a local proxy, use `gh api` with `--hostname github.com` for all GitHub API calls (not `gh pr create` which requires a GitHub remote).
+Use the `GH_TOKEN` environment variable with the `gh` CLI. The github plugin's SessionStart hook automatically sets `GH_HOST` and `GH_REPO` in web sessions, so standard `gh` subcommands (`gh pr create`, `gh issue list`, etc.) work normally.
 
-The `gh` CLI should already be configured via the mise or GitHub claude-code plugin. If `gh` is not available, investigate the startup hooks for those plugins..
+The `gh` CLI should already be configured via the mise or GitHub claude-code plugin. If `gh` is not available, investigate the startup hooks for those plugins.
 
 ## Creating a PR
 
@@ -42,7 +42,7 @@ After subsequent pushes, update the PR body to reflect all changes.
 
 ## Checking for an Existing PR
 
-Before creating, check if a PR already exists for the current branch. If one exists, update it instead of creating a new one. Use server-side filtering (e.g. `?head=nsheaps:<branch-name>&state=open`) for efficiency.
+Before creating, check if a PR already exists for the current branch. If one exists, update it instead of creating a new one (e.g. `gh pr list --head "<branch-name>" --state open`).
 
 ## PR Title Conventions
 

--- a/.claude/rules/ci-cd/conventions.md
+++ b/.claude/rules/ci-cd/conventions.md
@@ -115,20 +115,17 @@ CI on the latest commit of every branch is essential — it gates merges, valida
 
 **CRITICAL:** All CI checks must pass before a PR can be merged. After pushing changes:
 
-1. **Check CI status** using the GitHub API via `GH_TOKEN` (available in environment):
+1. **Check CI status** using `gh` (with `GH_HOST`/`GH_REPO` set automatically in web sessions):
    ```bash
    eval "$(mise activate bash)"
-   # Get check runs for latest commit on a PR
-   gh api repos/nsheaps/ai-mktpl/commits/<SHA>/check-runs \
-     --hostname github.com \
-     --jq '.check_runs[] | {name, status, conclusion}'
+   gh pr checks <PR_NUMBER>
    ```
 2. **Wait for checks to complete** — don't assume a push is done until CI reports back
 3. **Fix failures before moving on** — a failing CI is a blocker, not a "nice to have"
 4. **Review logs for failures** to understand root cause:
    ```bash
    eval "$(mise activate bash)"
-   gh api repos/nsheaps/ai-mktpl/actions/jobs/<JOB_ID>/logs --hostname github.com
+   gh run view <RUN_ID> --log
    ```
 
 ### Common CI Pitfalls
@@ -138,13 +135,13 @@ CI on the latest commit of every branch is essential — it gates merges, valida
 - **Run `mise run validate` locally** before pushing to catch validation errors early
 - **Run `mise run lint` locally** before pushing to catch linting issues
 
-### Accessing GitHub API in Web Sessions
+### Accessing GitHub in Web Sessions
 
-In Claude Code web sessions, `gh` is installed via mise but the remote is a local proxy. Use `--hostname github.com` with `gh api` commands, or use `GH_TOKEN` directly:
+In Claude Code web sessions, the github plugin automatically sets `GH_HOST=github.com` and `GH_REPO=nsheaps/ai-mktpl`, so all standard `gh` subcommands work normally:
 
 ```bash
 eval "$(mise activate bash)"
-gh api repos/nsheaps/ai-mktpl/pulls/<PR_NUMBER> --hostname github.com
+gh pr view <PR_NUMBER>
 ```
 
 ## Secrets Used

--- a/.claude/rules/workflow-self-improvement.md
+++ b/.claude/rules/workflow-self-improvement.md
@@ -1,0 +1,40 @@
+# Workflow Self-Improvement
+
+## Rule: Fix the System, Not Just the Symptom
+
+When you encounter a recurring problem and discover a workaround, **you MUST update the relevant skills, rules, or documentation** so future sessions don't hit the same issue. Working around a problem without improving the system is a missed opportunity.
+
+## When This Applies
+
+This applies whenever you:
+
+1. **Discover a command doesn't work as documented** — update the skill/docs to show the correct approach
+2. **Find a workaround for an environment issue** — add it to the troubleshooting section of the relevant skill or rule
+3. **Repeatedly do the same manual steps** — capture them in a skill or hook
+4. **Notice missing context in a skill** — add the context that would have saved you time
+5. **Hit a known limitation not documented** — document it where it will be found
+
+## What to Update
+
+| Problem Type | Where to Fix |
+|---|---|
+| CLI command doesn't work in context | Skill for that tool (e.g., `plugins/github/skills/gh/SKILL.md`) |
+| Environment-specific behavior | Rule file (e.g., `.claude/rules/`) or skill troubleshooting section |
+| Repeated manual workflow | Create or update a skill in the appropriate plugin |
+| Missing project convention | Rule file in `.claude/rules/` |
+| Recurring bug or gotcha | `ongoing-issues.md` + GitHub issue |
+
+## How to Apply
+
+1. **Identify the root cause** — why did the workaround become necessary?
+2. **Find the right file** — where would you have looked for this information?
+3. **Add the fix** — update that file with the correct guidance, prominently placed
+4. **Make it discoverable** — put critical information at the top, not buried at the bottom
+5. **Include the version bump** — plugin changes require a version bump per `versioning.md`
+
+## Anti-Patterns
+
+- Working around an issue 3+ times without updating docs
+- Adding a workaround in a rule file when it belongs in a skill (rules say *what*, skills say *how*)
+- Documenting the workaround only in a commit message where future sessions won't see it
+- Fixing the symptom in one place while the incorrect guidance remains in another

--- a/.claude/rules/workflow-self-improvement.md
+++ b/.claude/rules/workflow-self-improvement.md
@@ -16,13 +16,13 @@ This applies whenever you:
 
 ## What to Update
 
-| Problem Type | Where to Fix |
-|---|---|
-| CLI command doesn't work in context | Skill for that tool (e.g., `plugins/github/skills/gh/SKILL.md`) |
-| Environment-specific behavior | Rule file (e.g., `.claude/rules/`) or skill troubleshooting section |
-| Repeated manual workflow | Create or update a skill in the appropriate plugin |
-| Missing project convention | Rule file in `.claude/rules/` |
-| Recurring bug or gotcha | `ongoing-issues.md` + GitHub issue |
+| Problem Type                        | Where to Fix                                                        |
+| ----------------------------------- | ------------------------------------------------------------------- |
+| CLI command doesn't work in context | Skill for that tool (e.g., `plugins/github/skills/gh/SKILL.md`)     |
+| Environment-specific behavior       | Rule file (e.g., `.claude/rules/`) or skill troubleshooting section |
+| Repeated manual workflow            | Create or update a skill in the appropriate plugin                  |
+| Missing project convention          | Rule file in `.claude/rules/`                                       |
+| Recurring bug or gotcha             | `ongoing-issues.md` + GitHub issue                                  |
 
 ## How to Apply
 
@@ -35,6 +35,6 @@ This applies whenever you:
 ## Anti-Patterns
 
 - Working around an issue 3+ times without updating docs
-- Adding a workaround in a rule file when it belongs in a skill (rules say *what*, skills say *how*)
+- Adding a workaround in a rule file when it belongs in a skill (rules say _what_, skills say _how_)
 - Documenting the workaround only in a commit message where future sessions won't see it
 - Fixing the symptom in one place while the incorrect guidance remains in another

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -55,7 +55,9 @@
       "Bash(chmod:*)",
       "Bash(readlink:*)"
     ],
-    "deny": ["Bash(rm -rf /:*)"],
+    "deny": [
+      "Bash(rm -rf /:*)"
+    ],
     "ask": [
       "Bash(gh pr view --web:*)",
       "Bash(rm -rf:*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -55,9 +55,7 @@
       "Bash(chmod:*)",
       "Bash(readlink:*)"
     ],
-    "deny": [
-      "Bash(rm -rf /:*)"
-    ],
+    "deny": ["Bash(rm -rf /:*)"],
     "ask": [
       "Bash(gh pr view --web:*)",
       "Bash(rm -rf:*)",

--- a/mise.toml
+++ b/mise.toml
@@ -10,11 +10,12 @@ bun = "latest"
 "npm:eslint" = "latest"
 yarn = "latest"
 
-# 1Password CLI
-# NOTE: op-exec is a standalone script, not an asdf-style versioned tool.
-# It was removed from mise.toml because it lacks list-all/install scripts,
-# causing "Failed to run list-all" errors on every bash command.
-# Install op-exec separately if needed.
+# 1Password CLI and op-exec
+# TODO(#293): op-exec is commented out — it's a standalone script, not an
+# asdf-style versioned tool. It lacks list-all/install scripts, causing
+# "Failed to run list-all" errors on every bash command. Needs proper
+# mise backend or manual install approach.
+# "github:nsheaps/op-exec" = "latest"
 1password = "latest"
 
 [settings]

--- a/mise.toml
+++ b/mise.toml
@@ -10,8 +10,11 @@ bun = "latest"
 "npm:eslint" = "latest"
 yarn = "latest"
 
-# 1Password CLI and op-exec
-"github:nsheaps/op-exec" = "latest"
+# 1Password CLI
+# NOTE: op-exec is a standalone script, not an asdf-style versioned tool.
+# It was removed from mise.toml because it lacks list-all/install scripts,
+# causing "Failed to run list-all" errors on every bash command.
+# Install op-exec separately if needed.
 1password = "latest"
 
 [settings]

--- a/plugins/github/.claude-plugin/plugin.json
+++ b/plugins/github/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "GitHub CLI installation, authentication, and workflow skill for Claude Code sessions. Consolidates gh-tool and github-auth-skill into a single plugin.",
   "author": {
     "name": "Nathan Heaps",

--- a/plugins/github/.claude-plugin/plugin.json
+++ b/plugins/github/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "0.1.13",
+  "version": "0.2.0",
   "description": "GitHub CLI installation, authentication, and workflow skill for Claude Code sessions. Consolidates gh-tool and github-auth-skill into a single plugin.",
   "author": {
     "name": "Nathan Heaps",

--- a/plugins/github/hooks/scripts/install-gh.sh
+++ b/plugins/github/hooks/scripts/install-gh.sh
@@ -114,6 +114,36 @@ do_install() {
     hook_log_step "auth-check" "Checking GitHub CLI authentication"
     "$gh_bin" auth status 2>&1 || hook_log "gh auth not configured"
   fi
+
+  # --- Set GH_HOST and GH_REPO so regular gh subcommands work in web sessions ---
+  # In web sessions the git remote is a local proxy, so gh can't infer the
+  # GitHub host or repo.  Setting these env vars fixes that globally.
+  # See: https://cli.github.com/manual/gh_help_environment
+  hook_log_step "env-vars" "Configuring GH_HOST and GH_REPO for web session"
+
+  if [ -z "${GH_HOST:-}" ]; then
+    export GH_HOST="github.com"
+    if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+      echo 'export GH_HOST="github.com"' >> "$CLAUDE_ENV_FILE"
+    fi
+    hook_log "Set GH_HOST=github.com"
+  fi
+
+  if [ -z "${GH_REPO:-}" ]; then
+    # Try to infer owner/repo from the git remote URL
+    local repo_slug=""
+    repo_slug="$(git remote get-url origin 2>/dev/null \
+      | sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#' 2>/dev/null || true)"
+    if [ -n "$repo_slug" ]; then
+      export GH_REPO="$repo_slug"
+      if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+        echo "export GH_REPO=\"$repo_slug\"" >> "$CLAUDE_ENV_FILE"
+      fi
+      hook_log "Set GH_REPO=$repo_slug"
+    else
+      hook_log "Could not infer GH_REPO from git remote"
+    fi
+  fi
 }
 
 # --- Execute ---

--- a/plugins/github/skills/gh/SKILL.md
+++ b/plugins/github/skills/gh/SKILL.md
@@ -13,64 +13,41 @@ description: >
 The GitHub CLI (`gh`) brings GitHub workflows to the terminal. It provides
 commands for pull requests, issues, repos, actions, and direct API access.
 
-## Web Session Proxy — CRITICAL
+## Web Sessions
 
-**In Claude Code web sessions, the git remote is a local proxy, NOT github.com.** This means `gh` subcommands that infer the repo from the git remote (`gh pr create`, `gh pr list`, `gh issue list`, `gh pr view`, etc.) **will fail or target the wrong host**.
+In Claude Code web sessions, the git remote is a local proxy, not github.com. The `gh` CLI infers the host and repo from the remote, so subcommands like `gh pr create` would fail without configuration.
 
-### What Works and What Doesn't
+### Solution: GH_HOST and GH_REPO Environment Variables
 
-| Approach                                            | Web Session                      | Local Session |
-| --------------------------------------------------- | -------------------------------- | ------------- |
-| `gh api --hostname github.com repos/OWNER/REPO/...` | **Works**                        | Works         |
-| `gh pr create`, `gh pr list`, `gh issue list`, etc. | **Fails** (proxy remote)         | Works         |
-| `gh api repos/OWNER/REPO/...` (no --hostname)       | **May fail** (resolves to proxy) | Works         |
-
-### Always-Safe Pattern
-
-**Always use `gh api` with `--hostname github.com` and explicit `repos/OWNER/REPO` paths.** This works in both web and local sessions:
+The github plugin's SessionStart hook **automatically sets** `GH_HOST` and `GH_REPO` in web sessions. Once set, all standard `gh` subcommands work normally:
 
 ```bash
-# Instead of: gh pr list
-gh api "repos/OWNER/REPO/pulls?state=open" --hostname github.com --jq '.[].title'
-
-# Instead of: gh pr create --title "..." --body "..."
-gh api repos/OWNER/REPO/pulls --hostname github.com \
-  --method POST \
-  --field title="Title" \
-  --field head="branch-name" \
-  --field base="main" \
-  --field draft=true \
-  --field body="Description"
-
-# Instead of: gh issue list
-gh api "repos/OWNER/REPO/issues?state=open" --hostname github.com --jq '.[].title'
-
-# Instead of: gh issue create --title "..." --body "..."
-gh api repos/OWNER/REPO/issues --hostname github.com \
-  --method POST \
-  --field title="Title" \
-  --field body="Description"
-
-# Instead of: gh pr view 123
-gh api repos/OWNER/REPO/pulls/123 --hostname github.com
-
-# Instead of: gh pr merge 123 --squash
-gh api repos/OWNER/REPO/pulls/123/merge --hostname github.com \
-  --method PUT \
-  --field merge_method="squash"
+# These all work in web sessions when GH_HOST and GH_REPO are set:
+gh pr create --draft --title "Add feature X" --body "Description"
+gh pr list
+gh pr view 123
+gh issue create --title "Bug: X" --body "Details"
+gh issue list --label "bug"
+gh run list
+gh run view 12345 --log
 ```
 
-### Detecting Web Sessions
+If for some reason the env vars are not set (e.g., hook didn't run), set them manually:
 
 ```bash
-if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
-  echo "Web session — use gh api --hostname github.com"
-fi
+export GH_HOST="github.com"
+export GH_REPO="owner/repo"  # inferred from git remote by the hook
 ```
 
-### Why This Happens
+Reference: https://cli.github.com/manual/gh_help_environment
 
-Claude Code web sessions route git operations through a local proxy for security. The `gh` CLI reads the git remote to determine the GitHub host, so it resolves to the proxy instead of `github.com`. Using `--hostname github.com` explicitly overrides this.
+### Fallback: gh api
+
+For edge cases or direct API access, `gh api` with `--hostname github.com` always works:
+
+```bash
+gh api repos/OWNER/REPO/pulls --hostname github.com --jq '.[].title'
+```
 
 ## Quick Reference
 
@@ -135,19 +112,25 @@ gh api users/my-app[bot] --jq '.id'
 
 ## Pull Request Workflows
 
-> **Reminder:** In web sessions, use `gh api --hostname github.com` instead of `gh pr` subcommands. See [Web Session Proxy](#web-session-proxy--critical) above.
+> **Note:** In web sessions, `GH_HOST` and `GH_REPO` are set automatically by the github plugin. All `gh pr` subcommands work normally.
 
 ### Creating PRs
 
 ```bash
-# Via gh api (works in all sessions)
-gh api repos/OWNER/REPO/pulls --hostname github.com \
-  --method POST \
-  --field title="Add feature X" \
-  --field head="branch-name" \
-  --field base="main" \
-  --field draft=true \
-  --field body="$(cat <<'EOF'
+# Create a PR
+gh pr create --title "Add feature X" --body "Description here"
+
+# Create as draft
+gh pr create --draft --title "WIP: Feature Z"
+
+# Target a specific base branch
+gh pr create --base develop --title "Feature for develop"
+
+# Create with labels
+gh pr create --draft --title "Fix bug" --label "bug"
+
+# Multi-line body
+gh pr create --draft --title "Add feature X" --body "$(cat <<'EOF'
 ## Summary
 - Fixed the thing
 
@@ -155,134 +138,84 @@ gh api repos/OWNER/REPO/pulls --hostname github.com \
 - [ ] Unit tests pass
 EOF
 )"
-
-# Add labels after creation
-gh api repos/OWNER/REPO/issues/PR_NUMBER/labels --hostname github.com \
-  --method POST --field 'labels[]=bug'
-
-# Local-only alternatives (won't work in web sessions):
-# gh pr create --title "Add feature X" --body "Description here"
-# gh pr create --draft --title "WIP: Feature Z"
-# gh pr create --base develop --title "Feature for develop"
 ```
 
 ### Reviewing PRs
 
 ```bash
 # View PR details
-gh api repos/OWNER/REPO/pulls/123 --hostname github.com
+gh pr view 123
 
-# View PR files
-gh api repos/OWNER/REPO/pulls/123/files --hostname github.com \
-  --jq '.[].filename'
+# View PR diff
+gh pr diff 123
 
-# Check PR status (CI checks)
-gh api repos/OWNER/REPO/commits/SHA/check-runs --hostname github.com \
-  --jq '.check_runs[] | {name, status, conclusion}'
+# Check CI status
+gh pr checks 123
 
-# View PR comments
-gh api repos/OWNER/REPO/pulls/123/comments --hostname github.com
+# View PR as JSON
+gh pr view 123 --json title,state,reviews,statusCheckRollup
 
-# View PR review comments
-gh api repos/OWNER/REPO/pulls/123/reviews --hostname github.com
-
-# Create a review
-gh api repos/OWNER/REPO/pulls/123/reviews --hostname github.com \
-  --method POST \
-  --field event="COMMENT" \
-  --field body="LGTM!"
-
-# Local-only alternatives:
-# gh pr view 123
-# gh pr diff 123
-# gh pr checks 123
+# Create a review comment
+gh pr review 123 --comment --body "LGTM!"
 ```
 
 ### Managing PRs
 
 ```bash
 # List open PRs
-gh api "repos/OWNER/REPO/pulls?state=open" --hostname github.com \
-  --jq '.[] | {number, title, user: .user.login}'
+gh pr list
 
 # List PRs by author
-gh api "repos/OWNER/REPO/pulls?state=open" --hostname github.com \
-  --jq '[.[] | select(.user.login == "USERNAME")] | .[] | {number, title}'
+gh pr list --author USERNAME
 
-# Update PR (title, body, etc.)
-gh api repos/OWNER/REPO/pulls/123 --hostname github.com \
-  --method PATCH \
-  --field title="Updated title" \
-  --field body="Updated body"
+# Edit PR title/body
+gh pr edit 123 --title "Updated title" --body "Updated body"
 
-# Merge a PR (squash)
-gh api repos/OWNER/REPO/pulls/123/merge --hostname github.com \
-  --method PUT \
-  --field merge_method="squash"
+# Add labels
+gh pr edit 123 --add-label "bug,priority:high"
+
+# Merge (squash)
+gh pr merge 123 --squash
 
 # Close without merging
-gh api repos/OWNER/REPO/pulls/123 --hostname github.com \
-  --method PATCH \
-  --field state="closed"
-
-# Local-only alternatives:
-# gh pr list
-# gh pr merge 123 --squash
-# gh pr close 123
+gh pr close 123
 ```
 
 ## Issue Workflows
 
-> **Reminder:** In web sessions, use `gh api --hostname github.com` instead of `gh issue` subcommands.
+> **Note:** In web sessions, `GH_HOST` and `GH_REPO` are set automatically by the github plugin. All `gh issue` subcommands work normally.
 
 ### Creating Issues
 
 ```bash
-# Via gh api (works in all sessions)
-gh api repos/OWNER/REPO/issues --hostname github.com \
-  --method POST \
-  --field title="Bug: X crashes" \
-  --field body="Steps to reproduce..." \
-  --field 'labels[]=bug' \
-  --field 'labels[]=priority:high'
+# Create an issue
+gh issue create --title "Bug: X crashes" --body "Steps to reproduce..."
 
-# Local-only alternatives:
-# gh issue create --title "Bug: X crashes" --body "Steps to reproduce..."
-# gh issue create --title "Feature request" --label "enhancement"
+# Create with labels
+gh issue create --title "Bug: X crashes" --label "bug" --label "priority:high"
 ```
 
 ### Managing Issues
 
 ```bash
 # List open issues
-gh api "repos/OWNER/REPO/issues?state=open" --hostname github.com \
-  --jq '.[] | {number, title}'
+gh issue list
 
 # List issues with label
-gh api "repos/OWNER/REPO/issues?labels=bug&state=open" --hostname github.com \
-  --jq '.[] | {number, title}'
+gh issue list --label "bug"
 
 # View issue details
-gh api repos/OWNER/REPO/issues/42 --hostname github.com
+gh issue view 42
 
 # Close issue with comment
-gh api repos/OWNER/REPO/issues/42/comments --hostname github.com \
-  --method POST --field body="Fixed in #123"
-gh api repos/OWNER/REPO/issues/42 --hostname github.com \
-  --method PATCH --field state="closed"
+gh issue close 42 --comment "Fixed in #123"
 
 # Add/remove labels
-gh api repos/OWNER/REPO/issues/42/labels --hostname github.com \
-  --method POST --field 'labels[]=status:in-progress'
+gh issue edit 42 --add-label "status:in-progress"
+gh issue edit 42 --remove-label "status:in-progress"
 
 # Add comment
-gh api repos/OWNER/REPO/issues/42/comments --hostname github.com \
-  --method POST --field body="Working on this"
-
-# Local-only alternatives:
-# gh issue list --label "bug"
-# gh issue view 42
-# gh issue close 42 --comment "Fixed in #123"
+gh issue comment 42 --body "Working on this"
 ```
 
 ## Repository Operations
@@ -309,48 +242,34 @@ gh repo edit --enable-auto-merge --delete-branch-on-merge
 
 ## GitHub Actions
 
-> **Reminder:** In web sessions, use `gh api --hostname github.com` instead of `gh run`/`gh workflow` subcommands.
+> **Note:** In web sessions, `GH_HOST` and `GH_REPO` are set automatically by the github plugin. All `gh run`/`gh workflow` subcommands work normally.
 
 ```bash
 # List recent workflow runs
-gh api repos/OWNER/REPO/actions/runs --hostname github.com \
-  --jq '.workflow_runs[:10] | .[] | {id, name: .name, status, conclusion}'
+gh run list --limit 10
 
 # View a specific run
-gh api repos/OWNER/REPO/actions/runs/12345 --hostname github.com
+gh run view 12345
 
-# View run jobs
-gh api repos/OWNER/REPO/actions/runs/12345/jobs --hostname github.com \
-  --jq '.jobs[] | {name, status, conclusion}'
-
-# View job logs
-gh api repos/OWNER/REPO/actions/jobs/JOB_ID/logs --hostname github.com
+# View run logs
+gh run view 12345 --log
 
 # Re-run a failed workflow
-gh api repos/OWNER/REPO/actions/runs/12345/rerun --hostname github.com \
-  --method POST
+gh run rerun 12345
 
 # Re-run only failed jobs
-gh api repos/OWNER/REPO/actions/runs/12345/rerun-failed-jobs --hostname github.com \
-  --method POST
+gh run rerun 12345 --failed
 
 # Trigger a workflow dispatch
-gh api repos/OWNER/REPO/actions/workflows/ci.yaml/dispatches --hostname github.com \
-  --method POST --field ref="main"
+gh workflow run ci.yaml --ref main
 
 # List workflows
-gh api repos/OWNER/REPO/actions/workflows --hostname github.com \
-  --jq '.workflows[] | {name, state}'
-
-# Local-only alternatives:
-# gh run list
-# gh run view 12345 --log
-# gh workflow run ci.yaml --ref main
+gh workflow list
 ```
 
 ## GitHub API Access
 
-The `gh api` command provides authenticated access to any GitHub API endpoint. **Always include `--hostname github.com`** to ensure correct routing in web sessions.
+The `gh api` command provides authenticated access to any GitHub API endpoint. When `GH_HOST` is set (automatic in web sessions), `--hostname` is not required. Include `--hostname github.com` as a fallback if env vars aren't set.
 
 ### Common API Patterns
 
@@ -525,7 +444,14 @@ Place in:
 
 ### `gh pr create` / `gh issue list` fails in web sessions
 
-This is the most common issue. The git remote points to a local proxy, so `gh` subcommands that infer the repo from the remote will fail. **Use `gh api --hostname github.com` with explicit repo paths instead.** See [Web Session Proxy](#web-session-proxy--critical) at the top of this document.
+The git remote points to a local proxy in web sessions. The github plugin's SessionStart hook sets `GH_HOST` and `GH_REPO` automatically to fix this. If the hook hasn't run yet, set them manually:
+
+```bash
+export GH_HOST="github.com"
+export GH_REPO="owner/repo"
+```
+
+As a fallback, `gh api --hostname github.com` with explicit repo paths always works.
 
 ### Authentication issues
 

--- a/plugins/github/skills/gh/SKILL.md
+++ b/plugins/github/skills/gh/SKILL.md
@@ -13,6 +13,65 @@ description: >
 The GitHub CLI (`gh`) brings GitHub workflows to the terminal. It provides
 commands for pull requests, issues, repos, actions, and direct API access.
 
+## Web Session Proxy — CRITICAL
+
+**In Claude Code web sessions, the git remote is a local proxy, NOT github.com.** This means `gh` subcommands that infer the repo from the git remote (`gh pr create`, `gh pr list`, `gh issue list`, `gh pr view`, etc.) **will fail or target the wrong host**.
+
+### What Works and What Doesn't
+
+| Approach | Web Session | Local Session |
+|---|---|---|
+| `gh api --hostname github.com repos/OWNER/REPO/...` | **Works** | Works |
+| `gh pr create`, `gh pr list`, `gh issue list`, etc. | **Fails** (proxy remote) | Works |
+| `gh api repos/OWNER/REPO/...` (no --hostname) | **May fail** (resolves to proxy) | Works |
+
+### Always-Safe Pattern
+
+**Always use `gh api` with `--hostname github.com` and explicit `repos/OWNER/REPO` paths.** This works in both web and local sessions:
+
+```bash
+# Instead of: gh pr list
+gh api "repos/OWNER/REPO/pulls?state=open" --hostname github.com --jq '.[].title'
+
+# Instead of: gh pr create --title "..." --body "..."
+gh api repos/OWNER/REPO/pulls --hostname github.com \
+  --method POST \
+  --field title="Title" \
+  --field head="branch-name" \
+  --field base="main" \
+  --field draft=true \
+  --field body="Description"
+
+# Instead of: gh issue list
+gh api "repos/OWNER/REPO/issues?state=open" --hostname github.com --jq '.[].title'
+
+# Instead of: gh issue create --title "..." --body "..."
+gh api repos/OWNER/REPO/issues --hostname github.com \
+  --method POST \
+  --field title="Title" \
+  --field body="Description"
+
+# Instead of: gh pr view 123
+gh api repos/OWNER/REPO/pulls/123 --hostname github.com
+
+# Instead of: gh pr merge 123 --squash
+gh api repos/OWNER/REPO/pulls/123/merge --hostname github.com \
+  --method PUT \
+  --field merge_method="squash"
+```
+
+### Detecting Web Sessions
+
+```bash
+if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
+  echo "Web session — use gh api --hostname github.com"
+fi
+```
+
+### Why This Happens
+
+Claude Code web sessions route git operations through a local proxy for security. The `gh` CLI reads the git remote to determine the GitHub host, so it resolves to the proxy instead of `github.com`. Using `--hostname github.com` explicitly overrides this.
+
 ## Quick Reference
 
 ### Authentication
@@ -21,11 +80,12 @@ commands for pull requests, issues, repos, actions, and direct API access.
 # Check auth status
 gh auth status
 
-# Login interactively
-gh auth login
-
 # Login with token (CI/web sessions)
-echo "$GH_TOKEN" | gh auth login --with-token
+# GH_TOKEN env var is preferred — gh respects it automatically
+export GH_TOKEN="ghp_..."
+
+# Login interactively (local only)
+gh auth login
 
 # Switch between accounts
 gh auth switch
@@ -75,14 +135,19 @@ gh api users/my-app[bot] --jq '.id'
 
 ## Pull Request Workflows
 
+> **Reminder:** In web sessions, use `gh api --hostname github.com` instead of `gh pr` subcommands. See [Web Session Proxy](#web-session-proxy--critical) above.
+
 ### Creating PRs
 
 ```bash
-# Create PR with title and body
-gh pr create --title "Add feature X" --body "Description here"
-
-# Create PR with body from heredoc
-gh pr create --title "Fix bug Y" --body "$(cat <<'EOF'
+# Via gh api (works in all sessions)
+gh api repos/OWNER/REPO/pulls --hostname github.com \
+  --method POST \
+  --field title="Add feature X" \
+  --field head="branch-name" \
+  --field base="main" \
+  --field draft=true \
+  --field body="$(cat <<'EOF'
 ## Summary
 - Fixed the thing
 
@@ -91,120 +156,133 @@ gh pr create --title "Fix bug Y" --body "$(cat <<'EOF'
 EOF
 )"
 
-# Create draft PR
-gh pr create --draft --title "WIP: Feature Z"
+# Add labels after creation
+gh api repos/OWNER/REPO/issues/PR_NUMBER/labels --hostname github.com \
+  --method POST --field 'labels[]=bug'
 
-# Create PR targeting specific base branch
-gh pr create --base develop --title "Feature for develop"
-
-# Create PR and fill from commits
-gh pr create --fill
-
-# Create PR with labels and reviewers
-gh pr create --title "Fix" --label "bug" --reviewer "username"
+# Local-only alternatives (won't work in web sessions):
+# gh pr create --title "Add feature X" --body "Description here"
+# gh pr create --draft --title "WIP: Feature Z"
+# gh pr create --base develop --title "Feature for develop"
 ```
 
 ### Reviewing PRs
 
 ```bash
 # View PR details
-gh pr view 123
-gh pr view 123 --json title,body,reviews,mergeable
+gh api repos/OWNER/REPO/pulls/123 --hostname github.com
 
-# View PR diff
-gh pr diff 123
-
-# List PR files
-gh pr view 123 --json files --jq '.files[].path'
+# View PR files
+gh api repos/OWNER/REPO/pulls/123/files --hostname github.com \
+  --jq '.[].filename'
 
 # Check PR status (CI checks)
-gh pr checks 123
+gh api repos/OWNER/REPO/commits/SHA/check-runs --hostname github.com \
+  --jq '.check_runs[] | {name, status, conclusion}'
 
 # View PR comments
-gh api repos/{owner}/{repo}/pulls/123/comments
+gh api repos/OWNER/REPO/pulls/123/comments --hostname github.com
 
-# Add a review comment
-gh pr review 123 --comment --body "LGTM!"
+# View PR review comments
+gh api repos/OWNER/REPO/pulls/123/reviews --hostname github.com
 
-# Approve a PR
-gh pr review 123 --approve
+# Create a review
+gh api repos/OWNER/REPO/pulls/123/reviews --hostname github.com \
+  --method POST \
+  --field event="COMMENT" \
+  --field body="LGTM!"
 
-# Request changes
-gh pr review 123 --request-changes --body "Please fix X"
+# Local-only alternatives:
+# gh pr view 123
+# gh pr diff 123
+# gh pr checks 123
 ```
 
 ### Managing PRs
 
 ```bash
 # List open PRs
-gh pr list
+gh api "repos/OWNER/REPO/pulls?state=open" --hostname github.com \
+  --jq '.[] | {number, title, user: .user.login}'
 
 # List PRs by author
-gh pr list --author "@me"
+gh api "repos/OWNER/REPO/pulls?state=open" --hostname github.com \
+  --jq '[.[] | select(.user.login == "USERNAME")] | .[] | {number, title}'
 
-# List PRs with specific label
-gh pr list --label "needs-review"
+# Update PR (title, body, etc.)
+gh api repos/OWNER/REPO/pulls/123 --hostname github.com \
+  --method PATCH \
+  --field title="Updated title" \
+  --field body="Updated body"
 
-# Merge a PR (merge commit)
-gh pr merge 123
-
-# Squash merge
-gh pr merge 123 --squash
-
-# Rebase merge
-gh pr merge 123 --rebase
-
-# Auto-merge when checks pass
-gh pr merge 123 --auto --squash
+# Merge a PR (squash)
+gh api repos/OWNER/REPO/pulls/123/merge --hostname github.com \
+  --method PUT \
+  --field merge_method="squash"
 
 # Close without merging
-gh pr close 123
+gh api repos/OWNER/REPO/pulls/123 --hostname github.com \
+  --method PATCH \
+  --field state="closed"
 
-# Checkout PR branch locally
-gh pr checkout 123
+# Local-only alternatives:
+# gh pr list
+# gh pr merge 123 --squash
+# gh pr close 123
 ```
 
 ## Issue Workflows
 
+> **Reminder:** In web sessions, use `gh api --hostname github.com` instead of `gh issue` subcommands.
+
 ### Creating Issues
 
 ```bash
-# Create issue interactively
-gh issue create
+# Via gh api (works in all sessions)
+gh api repos/OWNER/REPO/issues --hostname github.com \
+  --method POST \
+  --field title="Bug: X crashes" \
+  --field body="Steps to reproduce..." \
+  --field 'labels[]=bug' \
+  --field 'labels[]=priority:high'
 
-# Create with title and body
-gh issue create --title "Bug: X crashes" --body "Steps to reproduce..."
-
-# Create with labels
-gh issue create --title "Feature request" --label "enhancement" --label "priority:high"
-
-# Create with assignee
-gh issue create --title "Fix Y" --assignee "@me"
+# Local-only alternatives:
+# gh issue create --title "Bug: X crashes" --body "Steps to reproduce..."
+# gh issue create --title "Feature request" --label "enhancement"
 ```
 
 ### Managing Issues
 
 ```bash
 # List open issues
-gh issue list
+gh api "repos/OWNER/REPO/issues?state=open" --hostname github.com \
+  --jq '.[] | {number, title}'
 
 # List issues with label
-gh issue list --label "bug"
-
-# List issues assigned to me
-gh issue list --assignee "@me"
+gh api "repos/OWNER/REPO/issues?labels=bug&state=open" --hostname github.com \
+  --jq '.[] | {number, title}'
 
 # View issue details
-gh issue view 42
+gh api repos/OWNER/REPO/issues/42 --hostname github.com
 
 # Close issue with comment
-gh issue close 42 --comment "Fixed in #123"
+gh api repos/OWNER/REPO/issues/42/comments --hostname github.com \
+  --method POST --field body="Fixed in #123"
+gh api repos/OWNER/REPO/issues/42 --hostname github.com \
+  --method PATCH --field state="closed"
 
-# Edit issue
-gh issue edit 42 --title "New title" --add-label "status:in-progress"
+# Add/remove labels
+gh api repos/OWNER/REPO/issues/42/labels --hostname github.com \
+  --method POST --field 'labels[]=status:in-progress'
 
 # Add comment
-gh issue comment 42 --body "Working on this"
+gh api repos/OWNER/REPO/issues/42/comments --hostname github.com \
+  --method POST --field body="Working on this"
+
+# Local-only alternatives:
+# gh issue list --label "bug"
+# gh issue view 42
+# gh issue close 42 --comment "Fixed in #123"
 ```
 
 ## Repository Operations
@@ -231,62 +309,74 @@ gh repo edit --enable-auto-merge --delete-branch-on-merge
 
 ## GitHub Actions
 
+> **Reminder:** In web sessions, use `gh api --hostname github.com` instead of `gh run`/`gh workflow` subcommands.
+
 ```bash
 # List recent workflow runs
-gh run list
+gh api repos/OWNER/REPO/actions/runs --hostname github.com \
+  --jq '.workflow_runs[:10] | .[] | {id, name: .name, status, conclusion}'
 
 # View a specific run
-gh run view 12345
+gh api repos/OWNER/REPO/actions/runs/12345 --hostname github.com
 
-# View run logs
-gh run view 12345 --log
+# View run jobs
+gh api repos/OWNER/REPO/actions/runs/12345/jobs --hostname github.com \
+  --jq '.jobs[] | {name, status, conclusion}'
 
-# Watch a running workflow
-gh run watch 12345
+# View job logs
+gh api repos/OWNER/REPO/actions/jobs/JOB_ID/logs --hostname github.com
 
 # Re-run a failed workflow
-gh run rerun 12345
+gh api repos/OWNER/REPO/actions/runs/12345/rerun --hostname github.com \
+  --method POST
 
 # Re-run only failed jobs
-gh run rerun 12345 --failed
+gh api repos/OWNER/REPO/actions/runs/12345/rerun-failed-jobs --hostname github.com \
+  --method POST
 
 # Trigger a workflow dispatch
-gh workflow run ci.yaml --ref main
+gh api repos/OWNER/REPO/actions/workflows/ci.yaml/dispatches --hostname github.com \
+  --method POST --field ref="main"
 
 # List workflows
-gh workflow list
+gh api repos/OWNER/REPO/actions/workflows --hostname github.com \
+  --jq '.workflows[] | {name, state}'
 
-# View workflow details
-gh workflow view ci.yaml
+# Local-only alternatives:
+# gh run list
+# gh run view 12345 --log
+# gh workflow run ci.yaml --ref main
 ```
 
 ## GitHub API Access
 
-The `gh api` command provides authenticated access to any GitHub API endpoint.
+The `gh api` command provides authenticated access to any GitHub API endpoint. **Always include `--hostname github.com`** to ensure correct routing in web sessions.
 
 ### Common API Patterns
 
 ```bash
 # GET request
-gh api repos/owner/repo
+gh api repos/owner/repo --hostname github.com
 
 # GET with jq filtering
-gh api repos/owner/repo --jq '.description'
+gh api repos/owner/repo --hostname github.com --jq '.description'
 
 # POST request (create)
-gh api repos/owner/repo/labels -f name="priority:critical" -f color="FF0000"
+gh api repos/owner/repo/labels --hostname github.com \
+  -f name="priority:critical" -f color="FF0000"
 
 # PATCH request (update)
-gh api repos/owner/repo/issues/42 -X PATCH -f state="closed"
+gh api repos/owner/repo/issues/42 --hostname github.com \
+  -X PATCH -f state="closed"
 
 # DELETE request
-gh api repos/owner/repo/labels/old-label -X DELETE
+gh api repos/owner/repo/labels/old-label --hostname github.com -X DELETE
 
 # Paginated results
-gh api repos/owner/repo/issues --paginate --jq '.[].title'
+gh api repos/owner/repo/issues --hostname github.com --paginate --jq '.[].title'
 
 # GraphQL query
-gh api graphql -f query='
+gh api graphql --hostname github.com -f query='
   query {
     repository(owner: "owner", name: "repo") {
       pullRequests(first: 10, states: OPEN) {
@@ -301,22 +391,25 @@ gh api graphql -f query='
 
 ```bash
 # Get file contents from a repo
-gh api repos/owner/repo/contents/path/to/file --jq '.content' | base64 -d
+gh api repos/owner/repo/contents/path/to/file --hostname github.com \
+  --jq '.content' | base64 -d
 
 # List PR review comments
-gh api repos/owner/repo/pulls/123/comments
+gh api repos/owner/repo/pulls/123/comments --hostname github.com
 
 # Get commit status
-gh api repos/owner/repo/commits/SHA/status
+gh api repos/owner/repo/commits/SHA/status --hostname github.com
 
 # List repository topics
-gh api repos/owner/repo/topics --jq '.names[]'
+gh api repos/owner/repo/topics --hostname github.com --jq '.names[]'
 
 # Search code
-gh api search/code -f q="pattern repo:owner/repo" --jq '.items[].path'
+gh api search/code --hostname github.com \
+  -f q="pattern repo:owner/repo" --jq '.items[].path'
 
 # Create a repository dispatch event
-gh api repos/owner/repo/dispatches -f event_type="deploy" -f client_payload='{"env":"prod"}'
+gh api repos/owner/repo/dispatches --hostname github.com \
+  -f event_type="deploy" -f client_payload='{"env":"prod"}'
 ```
 
 ## Releases
@@ -430,17 +523,24 @@ Place in:
 
 ## Troubleshooting
 
+### `gh pr create` / `gh issue list` fails in web sessions
+
+This is the most common issue. The git remote points to a local proxy, so `gh` subcommands that infer the repo from the remote will fail. **Use `gh api --hostname github.com` with explicit repo paths instead.** See [Web Session Proxy](#web-session-proxy--critical) at the top of this document.
+
 ### Authentication issues
 
 ```bash
 # Verify auth
 gh auth status
 
-# Re-authenticate
-gh auth login
+# Check if GH_TOKEN is set (preferred in web sessions)
+echo "${GH_TOKEN:+set}" || echo "not set"
 
 # Check token scopes
 gh auth status -t
+
+# Re-authenticate (local only)
+gh auth login
 ```
 
 ### "gh: command not found" in web sessions
@@ -454,7 +554,7 @@ Use authenticated requests (default with `gh`) to get 5,000 req/hour
 instead of 60. For heavy API usage, check remaining:
 
 ```bash
-gh api rate_limit --jq '.rate'
+gh api rate_limit --hostname github.com --jq '.rate'
 ```
 
 ### Working with GitHub Enterprise

--- a/plugins/github/skills/gh/SKILL.md
+++ b/plugins/github/skills/gh/SKILL.md
@@ -19,11 +19,11 @@ commands for pull requests, issues, repos, actions, and direct API access.
 
 ### What Works and What Doesn't
 
-| Approach | Web Session | Local Session |
-|---|---|---|
-| `gh api --hostname github.com repos/OWNER/REPO/...` | **Works** | Works |
-| `gh pr create`, `gh pr list`, `gh issue list`, etc. | **Fails** (proxy remote) | Works |
-| `gh api repos/OWNER/REPO/...` (no --hostname) | **May fail** (resolves to proxy) | Works |
+| Approach                                            | Web Session                      | Local Session |
+| --------------------------------------------------- | -------------------------------- | ------------- |
+| `gh api --hostname github.com repos/OWNER/REPO/...` | **Works**                        | Works         |
+| `gh pr create`, `gh pr list`, `gh issue list`, etc. | **Fails** (proxy remote)         | Works         |
+| `gh api repos/OWNER/REPO/...` (no --hostname)       | **May fail** (resolves to proxy) | Works         |
 
 ### Always-Safe Pattern
 

--- a/plugins/scm-utils/.claude-plugin/plugin.json
+++ b/plugins/scm-utils/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scm-utils",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Source control management utilities for improving interactions with branches and PRs, both locally and in CI environments",
   "author": {
     "name": "Nathan Heaps",

--- a/plugins/scm-utils/skills/making-great-prs/SKILL.md
+++ b/plugins/scm-utils/skills/making-great-prs/SKILL.md
@@ -101,9 +101,9 @@ gh pr ready <PR_NUMBER>
 
 ## Error Handling
 
-| Error                 | Resolution                                                          |
-| --------------------- | ------------------------------------------------------------------- |
-| `gh` not found        | Run `eval "$(mise activate bash)"` or `mise install`                |
+| Error                 | Resolution                                                         |
+| --------------------- | ------------------------------------------------------------------ |
+| `gh` not found        | Run `eval "$(mise activate bash)"` or `mise install`               |
 | 401 Unauthorized      | Check `GH_TOKEN` is set and has PR write scope                     |
 | 422 Validation failed | Branch may not exist on remote yet — push first                    |
 | PR already exists     | Use `gh pr edit` to update instead of `gh pr create`               |

--- a/plugins/scm-utils/skills/making-great-prs/SKILL.md
+++ b/plugins/scm-utils/skills/making-great-prs/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: Bash, Read, Grep, Glob
 
 # Making Great PRs
 
-Create and maintain pull requests for feature branches using `gh api` with `--hostname github.com` (required for web sessions where the git remote is a local proxy).
+Create and maintain pull requests for feature branches. The github plugin sets `GH_HOST` and `GH_REPO` automatically in web sessions, so standard `gh` subcommands work everywhere.
 
 ## Pre-fetched Context
 
@@ -27,12 +27,10 @@ The `gh` CLI must be available (installed via mise) and `GH_TOKEN` must be set i
 
 ## Step 1: Check for Existing PR
 
-Always check before creating to avoid duplicates. Use server-side filtering:
+Always check before creating to avoid duplicates:
 
 ```bash
-gh api "repos/nsheaps/ai-mktpl/pulls?head=nsheaps:<branch-name>&state=open" \
-  --hostname github.com \
-  --jq '.[0] | {number, title, state}'
+gh pr list --head "<branch-name>" --state open --json number,title --jq '.[0]'
 ```
 
 If a PR already exists, skip to [Step 3: Update PR](#step-3-update-pr).
@@ -40,14 +38,10 @@ If a PR already exists, skip to [Step 3: Update PR](#step-3-update-pr).
 ## Step 2: Create Draft PR
 
 ```bash
-PR_NUMBER=$(gh api repos/nsheaps/ai-mktpl/pulls \
-  --hostname github.com \
-  --method POST \
-  --field title="Short descriptive title" \
-  --field head="<branch-name>" \
-  --field base="main" \
-  --field draft=true \
-  --field body="$(cat <<'PREOF'
+PR_URL=$(gh pr create \
+  --draft \
+  --title "Short descriptive title" \
+  --body "$(cat <<'PREOF'
 ## Summary
 - What changed and why
 
@@ -56,16 +50,14 @@ PR_NUMBER=$(gh api repos/nsheaps/ai-mktpl/pulls \
 
 <!-- Include Claude Code session link if available, e.g.: https://claude.ai/code/session_XXXXX -->
 PREOF
-)" --jq '.number')
+)")
 ```
 
 Then add the `request-review` label to trigger AI code review:
 
 ```bash
-gh api repos/nsheaps/ai-mktpl/issues/${PR_NUMBER}/labels \
-  --hostname github.com \
-  --method POST \
-  --field 'labels[]=request-review'
+PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+gh pr edit "$PR_NUMBER" --add-label "request-review"
 ```
 
 ## Step 3: Update PR
@@ -73,10 +65,7 @@ gh api repos/nsheaps/ai-mktpl/issues/${PR_NUMBER}/labels \
 After subsequent pushes, update the PR body to reflect all current changes:
 
 ```bash
-gh api repos/nsheaps/ai-mktpl/pulls/<PR_NUMBER> \
-  --hostname github.com \
-  --method PATCH \
-  --field body="$(cat <<'PREOF'
+gh pr edit <PR_NUMBER> --body "$(cat <<'PREOF'
 ## Summary
 - Updated description reflecting all changes
 
@@ -93,10 +82,7 @@ PREOF
 Only after review feedback is addressed and CI passes:
 
 ```bash
-gh api repos/nsheaps/ai-mktpl/pulls/<PR_NUMBER> \
-  --hostname github.com \
-  --method PATCH \
-  --field draft=false
+gh pr ready <PR_NUMBER>
 ```
 
 ## PR Title Conventions
@@ -115,9 +101,10 @@ gh api repos/nsheaps/ai-mktpl/pulls/<PR_NUMBER> \
 
 ## Error Handling
 
-| Error                 | Resolution                                           |
-| --------------------- | ---------------------------------------------------- |
-| `gh` not found        | Run `eval "$(mise activate bash)"` or `mise install` |
-| 401 Unauthorized      | Check `GH_TOKEN` is set and has PR write scope       |
-| 422 Validation failed | Branch may not exist on remote yet — push first      |
-| PR already exists     | Use PATCH to update instead of POST to create        |
+| Error                 | Resolution                                                          |
+| --------------------- | ------------------------------------------------------------------- |
+| `gh` not found        | Run `eval "$(mise activate bash)"` or `mise install`                |
+| 401 Unauthorized      | Check `GH_TOKEN` is set and has PR write scope                     |
+| 422 Validation failed | Branch may not exist on remote yet — push first                    |
+| PR already exists     | Use `gh pr edit` to update instead of `gh pr create`               |
+| Host/repo not found   | Ensure `GH_HOST` and `GH_REPO` are set (automatic in web sessions) |


### PR DESCRIPTION
## Summary
- **Set GH_HOST and GH_REPO automatically** in the github plugin's SessionStart hook for web sessions, so all standard `gh` subcommands work without the `gh api --hostname` workaround
- Rewrote gh skill to document env var approach as primary, demoted `gh api --hostname` to fallback
- Rewrote auto-pr skill to use normal `gh pr create`/`gh pr edit` commands
- Updated `auto-pr-management.md` and `ci-cd/conventions.md` rules to match
- Added `workflow-self-improvement.md` rule for capturing workarounds as permanent fixes
- Commented out broken `github:nsheaps/op-exec` in `mise.toml` (#293)
- Bumped github plugin 0.2.0 → 0.3.0, scm-utils 0.1.13 → 0.1.14

## How it works
The hook infers `owner/repo` from the git remote URL (stripping the proxy prefix), then exports `GH_HOST=github.com` and `GH_REPO=owner/repo` via `CLAUDE_ENV_FILE`. This makes `gh` resolve the correct host and repo for all subcommands.

## Test plan
- [ ] Verify github plugin hook sets GH_HOST and GH_REPO in a web session
- [ ] Verify `gh pr list`, `gh issue list`, `gh run list` work in web sessions
- [ ] Verify env vars are NOT set when already present (idempotent)
- [ ] Confirm skill and rule docs are consistent with new approach

Closes #296
Related: #293

https://claude.ai/code/session_01G6P9dJwmvLepBNSf4u7YtK