### PR TITLE
feat: add CLAUDE.md for plugin development guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 | Plugin Development | `.claude/rules/plugin-development.md` |
 | Versioning         | `.claude/rules/versioning.md`         |
 | CI/CD Conventions  | `.claude/rules/ci-cd/conventions.md`  |
-| Project Summary    | `.claude/CLAUDE.md`                   |
+| Project Summary    | `CLAUDE.md`                           |
 
 ## Repository Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,16 +13,16 @@ This is the **ai-mktpl** plugin marketplace repository for Claude Code. It conta
 
 When creating or modifying any plugin component, you MUST recall and follow the appropriate `plugin-dev` skill:
 
-| Component       | Skill to recall                    |
-| --------------- | ---------------------------------- |
-| Plugin scaffold | `plugin-dev:plugin-structure`      |
-| Skills          | `plugin-dev:skill-development`     |
-| Hooks           | `plugin-dev:hook-development`      |
-| MCP servers     | `plugin-dev:mcp-integration`       |
-| Settings/config | `plugin-dev:plugin-settings`       |
-| Commands        | `plugin-dev:command-development`   |
-| Agents          | `plugin-dev:agent-development`     |
-| Creating new    | `plugin-dev:create-plugin`         |
+| Component       | Skill to recall                  |
+| --------------- | -------------------------------- |
+| Plugin scaffold | `plugin-dev:plugin-structure`    |
+| Skills          | `plugin-dev:skill-development`   |
+| Hooks           | `plugin-dev:hook-development`    |
+| MCP servers     | `plugin-dev:mcp-integration`     |
+| Settings/config | `plugin-dev:plugin-settings`     |
+| Commands        | `plugin-dev:command-development` |
+| Agents          | `plugin-dev:agent-development`   |
+| Creating new    | `plugin-dev:create-plugin`       |
 
 Always recall the relevant skill BEFORE writing code. These skills contain the canonical patterns, schema requirements, and validation steps.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This is the **ai-mktpl** plugin marketplace repository for Claude Code. It conta
 
 1. Read the repo overview: [README.md](README.md)
 2. Read the plugin schema: [docs/PLUGIN_SCHEMA.md](docs/PLUGIN_SCHEMA.md)
-3. Read the development rules: @.claude/rules/plugin-development.md
+3. Read the development rules: [.claude/rules/plugin-development.md](.claude/rules/plugin-development.md)
 4. Review existing plugins in `plugins/` for patterns before creating anything new
 
 ## Plugin Development Skills (CRITICAL)
@@ -22,7 +22,6 @@ When creating or modifying any plugin component, you MUST recall and follow the 
 | Settings/config | `plugin-dev:plugin-settings`     |
 | Commands        | `plugin-dev:command-development` |
 | Agents          | `plugin-dev:agent-development`   |
-| Creating new    | `plugin-dev:create-plugin`       |
 
 Always recall the relevant skill BEFORE writing code. These skills contain the canonical patterns, schema requirements, and validation steps.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# ai-mktpl -- Claude Code Plugin Marketplace
+
+This is the **ai-mktpl** plugin marketplace repository for Claude Code. It contains reusable plugins, organization-wide rules, agents, and commands.
+
+## Before You Start
+
+1. Read the repo overview: [README.md](README.md)
+2. Read the plugin schema: [docs/PLUGIN_SCHEMA.md](docs/PLUGIN_SCHEMA.md)
+3. Read the development rules: @.claude/rules/plugin-development.md
+4. Review existing plugins in `plugins/` for patterns before creating anything new
+
+## Plugin Development Skills (CRITICAL)
+
+When creating or modifying any plugin component, you MUST recall and follow the appropriate `plugin-dev` skill:
+
+| Component       | Skill to recall                    |
+| --------------- | ---------------------------------- |
+| Plugin scaffold | `plugin-dev:plugin-structure`      |
+| Skills          | `plugin-dev:skill-development`     |
+| Hooks           | `plugin-dev:hook-development`      |
+| MCP servers     | `plugin-dev:mcp-integration`       |
+| Settings/config | `plugin-dev:plugin-settings`       |
+| Commands        | `plugin-dev:command-development`   |
+| Agents          | `plugin-dev:agent-development`     |
+| Creating new    | `plugin-dev:create-plugin`         |
+
+Always recall the relevant skill BEFORE writing code. These skills contain the canonical patterns, schema requirements, and validation steps.
+
+## Rules
+
+All rules in `.claude/rules/` apply. Key ones:
+
+- **plugin-development.md** -- tech stack (Bun + TypeScript), structure requirements, rules vs skills
+- **versioning.md** -- when and how to bump plugin versions
+- **plugin-hooks-organization.md** -- how to structure hook files
+- **shared-libs.md** -- shared library conventions
+- **hook-output-patterns.md** -- stdout/stderr patterns for hooks
+
+## Patterns: Learn From Existing Plugins
+
+Before creating a new plugin, study at least 2-3 existing plugins in `plugins/` that have similar components (hooks, MCP servers, skills, commands). Match their conventions.
+
+## Documentation
+
+- [Installation guide](docs/installation.md)
+- [Plugin dependencies](docs/plugins-depending-on-another.md)
+- [Glossary](docs/glossary.md)
+- [Shared logging](docs/shared-logging.md)
+- Specs and research live in `docs/specs/` and `docs/research/`


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` to the repository root to guide AI agents working on plugin development
- Fixes pre-existing dead link in `AGENTS.md` line 12 (`.claude/CLAUDE.md` → `CLAUDE.md`)

## Changes

- `CLAUDE.md` (new): Plugin development workflow guide with skills table, key files list, and workflow steps
- `AGENTS.md` (fix): Updated Project Summary link to point to root `CLAUDE.md` instead of non-existent `.claude/CLAUDE.md`

## Review History

- Initial review: fixed phantom `plugin-dev:create-plugin` skill reference and inconsistent `@` syntax
- Second review: APPROVED (95% quality, both issues confirmed fixed)
- Third review: APPROVED (97% quality, all references verified, dead link follow-up noted)
- This push: addresses the non-blocking dead link follow-up in `AGENTS.md`

## Test Plan

- [x] All 7 `plugin-dev` skills verified against `claude-plugins-official` marketplace
- [x] All 11 file references and 3 directory references verified on filesystem
- [x] Dead link in `AGENTS.md` fixed (`.claude/CLAUDE.md` → `CLAUDE.md`)
- [x] CI passing

Co-Authored-By: Jack Oat (https://github.com/nsheaps/.ai-agent-jack) <jack-nsheaps[bot]@users.noreply.github.com>