### PR TITLE
fix: add word-boundary check to @claude trigger

### DIFF
--- a/.github/workflows/claude-agent-trigger.yaml
+++ b/.github/workflows/claude-agent-trigger.yaml
@@ -36,8 +36,8 @@ jobs:
           # Match @claude only when preceded by start-of-string, whitespace, or newline
           # and followed by end-of-string, whitespace, newline, or punctuation.
           # This prevents false positives like "plugin-dev@claude-plugins-official".
-          if echo "$COMMENT_BODY" | grep -qP '(^|\s)@claude(\s|$|[[:punct:]])' || \
-             echo "$ISSUE_TITLE"  | grep -qP '(^|\s)@claude(\s|$|[[:punct:]])'; then
+          if printf '%s\n' "$COMMENT_BODY" | grep -qP '(^|\s)@claude(\s|$|[[:punct:]])' || \
+             printf '%s\n' "$ISSUE_TITLE"  | grep -qP '(^|\s)@claude(\s|$|[[:punct:]])'; then
             echo "matched=true" >> "$GITHUB_OUTPUT"
           else
             echo "matched=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/claude-agent-trigger.yaml
+++ b/.github/workflows/claude-agent-trigger.yaml
@@ -15,6 +15,9 @@ on:
 
 jobs:
   dispatch:
+    # Pre-filter: only run if @claude appears somewhere in the event body/title.
+    # A second step (check-mention) applies a word-boundary regex to avoid
+    # false positives like "plugin-dev@claude-plugins-official".
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
@@ -24,7 +27,24 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Check for word-boundary @claude mention
+        id: check-mention
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body || '' }}
+          ISSUE_TITLE: ${{ github.event.issue.title || '' }}
+        run: |
+          # Match @claude only when preceded by start-of-string, whitespace, or newline
+          # and followed by end-of-string, whitespace, newline, or punctuation.
+          # This prevents false positives like "plugin-dev@claude-plugins-official".
+          if echo "$COMMENT_BODY" | grep -qP '(^|\s)@claude(\s|$|[[:punct:]])' || \
+             echo "$ISSUE_TITLE"  | grep -qP '(^|\s)@claude(\s|$|[[:punct:]])'; then
+            echo "matched=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "matched=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout and authenticate as GitHub App
+        if: steps.check-mention.outputs.matched == 'true'
         id: auth
         uses: nsheaps/github-actions/.github/actions/checkout-as-app@603052841cd49b9fdc99bc32979ff9c45c9b669e # checkout-as-app@main
         with:
@@ -33,6 +53,7 @@ jobs:
           persist-credentials: false
 
       - name: Dispatch to Claude agent
+        if: steps.check-mention.outputs.matched == 'true'
         uses: peter-evans/repository-dispatch@v4
         with:
           event-type: claude-agent

--- a/.github/workflows/claude-agent-trigger.yaml
+++ b/.github/workflows/claude-agent-trigger.yaml
@@ -33,11 +33,13 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body || '' }}
           ISSUE_TITLE: ${{ github.event.issue.title || '' }}
         run: |
-          # Match @claude only when preceded by start-of-string, whitespace, or newline
-          # and followed by end-of-string, whitespace, newline, or punctuation.
-          # This prevents false positives like "plugin-dev@claude-plugins-official".
-          if printf '%s\n' "$COMMENT_BODY" | grep -qP '(^|\s)@claude(\s|$|[[:punct:]])' || \
-             printf '%s\n' "$ISSUE_TITLE"  | grep -qP '(^|\s)@claude(\s|$|[[:punct:]])'; then
+          # Match @claude only when preceded by start-of-string or whitespace,
+          # and followed by end-of-string, whitespace, or a character that is NOT
+          # a word character or hyphen. [[:punct:]] includes '-', which caused
+          # @claude-code and @claude-* variants to incorrectly match. Using a
+          # negated class [^a-zA-Z0-9_-] explicitly excludes hyphens.
+          if printf '%s\n' "$COMMENT_BODY" | grep -qP '(^|\s)@claude(\s|$|[^a-zA-Z0-9_-])' || \
+             printf '%s\n' "$ISSUE_TITLE"  | grep -qP '(^|\s)@claude(\s|$|[^a-zA-Z0-9_-])'; then
             echo "matched=true" >> "$GITHUB_OUTPUT"
           else
             echo "matched=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Fixes a regex bug where `@claude-code` and other `@claude-*` variants incorrectly triggered the Claude agent
- Root cause: `[[:punct:]]` includes `-` (hyphen), so the trailing boundary matched `@claude-code`
- Fix: replace `[[:punct:]]` with negated class `[^a-zA-Z0-9_-]` to explicitly exclude hyphens

## Background

PR #390 triggered the Claude automation workflow because the PR body contained `plugin-dev@claude-plugins-official`. A word-boundary check was added (in that same PR), but it used `[[:punct:]]` as the trailing boundary — which includes `-`. This means `@claude-code` still matches because `-` is treated as valid punctuation.

## Approach

The existing `check-mention` step's Perl regex is updated:

- **Before**: `(^|\s)@claude(\s|$|[[:punct:]])`  — matches `@claude-code` ❌
- **After**: `(^|\s)@claude(\s|$|[^a-zA-Z0-9_-])` — only matches standalone `@claude` ✅

The negated character class `[^a-zA-Z0-9_-]` means: "NOT a letter, digit, underscore, or hyphen". This ensures `@claude-code`, `@claudebot`, and similar variants don't trigger the agent.

## Test cases verified

| Input | Expected | Result |
|-------|----------|--------|
| `@claude` | MATCH | ✅ |
| `hey @claude` | MATCH | ✅ |
| `@claude please review` | MATCH | ✅ |
| `@claude!` | MATCH | ✅ |
| `@claude.` | MATCH | ✅ |
| `@claude-code` | NO MATCH | ✅ |
| `@claude-plugins-official` | NO MATCH | ✅ |
| `@claudebot` | NO MATCH | ✅ |
| `plugin-dev@claude-plugins-official` | NO MATCH | ✅ |

## Test plan

- [ ] Verify workflow does NOT trigger for comments containing only `@claude-code`
- [ ] Verify workflow does NOT trigger for comments containing `plugin-dev@claude-plugins-official`
- [ ] Verify workflow DOES trigger when a comment contains standalone `@claude`
- [ ] Verify workflow DOES trigger for `@claude` at end of sentence with punctuation (`@claude!`)



Co-Authored-By: [Jack Oat](https://github.com/nsheaps/.ai-agent-jack) <jack-nsheaps[bot]@users.noreply.github.com>