### PR TITLE
fix: include workflow run URL in automation comments

### DIFF
--- a/.github/workflows/claude-agent.yaml
+++ b/.github/workflows/claude-agent.yaml
@@ -34,6 +34,7 @@ jobs:
         id: prompt
         env:
           PAYLOAD: ${{ toJson(github.event.client_payload) }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           # Extract values from payload
           PROMPT=$(echo "$PAYLOAD" | jq -r '.prompt // ""')
@@ -78,9 +79,13 @@ jobs:
           fi
           CONTEXT+="- Triggered by: $AUTHOR ($ASSOCIATION)\n"
           CONTEXT+="- Trigger: $TRIGGER_TYPE ($TRIGGER_ACTION)\n"
+          CONTEXT+="- Workflow run: $WORKFLOW_URL\n"
           if [ "$TITLE" != "null" ] && [ -n "$TITLE" ]; then
             CONTEXT+="\n## Title\n$TITLE\n"
           fi
+          CONTEXT+="\n## Attribution\n"
+          CONTEXT+="When posting comments, include a footer line linking to this workflow run for traceability:\n"
+          CONTEXT+="\`\`\`\n---\n_Automated by [Claude Agent]($WORKFLOW_URL)_\n\`\`\`\n"
           CONTEXT+="\n## User Request\n$PROMPT"
 
           # Output the full prompt (escape for multiline)

--- a/.github/workflows/claude-agent.yaml
+++ b/.github/workflows/claude-agent.yaml
@@ -84,8 +84,13 @@ jobs:
             CONTEXT+="\n## Title\n$TITLE\n"
           fi
           CONTEXT+="\n## Attribution\n"
-          CONTEXT+="When posting comments, include a footer line linking to this workflow run for traceability:\n"
-          CONTEXT+="\`\`\`\n---\n_Automated by [Claude Agent]($WORKFLOW_URL)_\n\`\`\`\n"
+          CONTEXT+="When posting comments, append GitHub-flavored markdown footnotes at the end for traceability:\n"
+          CONTEXT+="[^1]: Workflow Run: [$REPO actions/runs/${{ github.run_id }}]($WORKFLOW_URL)\n"
+          if [ "$PR_NUM" != "null" ] && [ -n "$PR_NUM" ]; then
+            CONTEXT+="[^2]: PR: [$REPO#$PR_NUM](${{ github.server_url }}/${{ github.repository }}/pull/$PR_NUM)\n"
+          elif [ "$ISSUE_NUM" != "null" ] && [ -n "$ISSUE_NUM" ]; then
+            CONTEXT+="[^2]: Issue: [$REPO#$ISSUE_NUM](${{ github.server_url }}/${{ github.repository }}/issues/$ISSUE_NUM)\n"
+          fi
           CONTEXT+="\n## User Request\n$PROMPT"
 
           # Output the full prompt (escape for multiline)


### PR DESCRIPTION
## Summary

- Adds the workflow run URL to the Claude agent's prompt context
- Instructs Claude to include an attribution footer linking to the workflow run in all comments it posts
- Enables traceability from automated comments back to the specific workflow run

## Background

Issue 4 from PR #390 review: automated comments posted by the Claude agent had no link back to the workflow run that generated them. This made it difficult to debug or understand why a comment was posted.

## Approach

The workflow run URL is constructed from GitHub's built-in environment variables (`GITHUB_SERVER_URL`, `GITHUB_REPOSITORY`, `GITHUB_RUN_ID`) and passed into the prompt builder step as an env var. The URL is added to the context section and an "Attribution" section instructs Claude to append a footer line like:

```
---
_Automated by [Claude Agent](https://github.com/nsheaps/ai-mktpl/actions/runs/12345)_
```

## Test plan

- [ ] Trigger the workflow with an `@claude` mention and verify the comment includes the workflow link footer
- [ ] Verify the workflow URL resolves to the correct run



Co-Authored-By: [Jack Oat](https://github.com/nsheaps/.ai-agent-jack) <jack-nsheaps[bot]@users.noreply.github.com>