### PR TITLE
feat(github-app): gh auth isolation and proactive token refresh

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -356,7 +356,7 @@
     {
       "name": "github-app",
       "description": "Automatic GitHub App token lifecycle for Claude Code sessions. Generates installation tokens on session start, monitors expiry via PreToolUse hook, and refreshes transparently before commands that need authentication.",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "author": {
         "name": "Nathan Heaps"
       },

--- a/plugins/github-app/.claude-plugin/plugin.json
+++ b/plugins/github-app/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-app",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Automatic GitHub App token lifecycle for Claude Code sessions. Generates installation tokens on session start, monitors expiry via PreToolUse hook, and refreshes transparently before commands that need authentication.",
   "author": {
     "name": "Nathan Heaps",

--- a/plugins/github-app/bin/token-check.sh
+++ b/plugins/github-app/bin/token-check.sh
@@ -37,7 +37,7 @@ META_FILE="${TOKEN_FILE}.meta"
 ENV_RUNTIME_FILE="${GITHUB_APP_ENV_FILE:-$HOME/.config/agent/github-app-env}"
 LOCKFILE="${TOKEN_FILE}.lock"
 COOLDOWN_FILE="${TOKEN_FILE}.cooldown"
-REFRESH_THRESHOLD_MINUTES=30
+REFRESH_THRESHOLD_MINUTES=45  # Proactively refresh when <=45 min remain (token lasts 1h)
 MAX_RETRIES=3
 COOLDOWN_SECONDS=300
 

--- a/plugins/github-app/bin/token-check.sh
+++ b/plugins/github-app/bin/token-check.sh
@@ -108,6 +108,8 @@ export GITHUB_APP_ENV_FILE="$ENV_RUNTIME_FILE"
 ENVEOF
   [[ -n "${GITHUB_APP_CLIENT_ID:-}" ]] && echo "export GITHUB_APP_CLIENT_ID=\"$GITHUB_APP_CLIENT_ID\"" >> "$ENV_RUNTIME_FILE"
   [[ -n "${GITHUB_APP_CLIENT_SECRET:-}" ]] && echo "export GITHUB_APP_CLIENT_SECRET=\"$GITHUB_APP_CLIENT_SECRET\"" >> "$ENV_RUNTIME_FILE"
+  # Preserve GH_CONFIG_DIR isolation across token refreshes
+  [[ -n "${GH_CONFIG_DIR:-}" ]] && echo "export GH_CONFIG_DIR=\"$GH_CONFIG_DIR\"" >> "$ENV_RUNTIME_FILE"
   chmod 600 "$ENV_RUNTIME_FILE"
 }
 

--- a/plugins/github-app/hooks/scripts/github-token-check.sh
+++ b/plugins/github-app/hooks/scripts/github-token-check.sh
@@ -6,7 +6,7 @@
 #
 # Behavior:
 #   - Bash commands using gh/git: synchronous check before execution
-#     - If token valid but close to expiry: allow + background refresh
+#     - If token valid but close to expiry (<=45 min): allow + background refresh
 #     - If token expired: synchronous refresh, then allow
 #   - All other tools: async check, never blocks
 #   - Successful refreshes update the runtime env file so subsequent
@@ -22,7 +22,8 @@ set -euo pipefail
 # --- Configuration ---
 
 DEBOUNCE_FILE="${HOME}/.config/agent/github-app-last-check"
-DEBOUNCE_SECONDS=30  # Don't check more often than every 30 seconds
+DEBOUNCE_SECONDS=30    # Don't check more often than every 30 seconds
+REFRESH_THRESHOLD=45   # Proactively refresh when <=45 min remain (token lasts 1h)
 TOKEN_FILE="${GITHUB_TOKEN_FILE:-$HOME/.config/agent/github-token}"
 META_FILE="${TOKEN_FILE}.meta"
 
@@ -128,7 +129,7 @@ if uses_token; then
       allow_silent
       ;;
     *)
-      if (( MINUTES <= 30 )); then
+      if (( MINUTES <= REFRESH_THRESHOLD )); then
         # Valid but close to expiry — allow + background refresh
         echo "github-app: token valid, but close to expiration, refreshing in the background" >&2
         "$BIN_DIR/token-check.sh" --quiet 2>/dev/null &
@@ -160,7 +161,7 @@ else
       allow_silent
       ;;
     *)
-      if (( MINUTES <= 30 )); then
+      if (( MINUTES <= REFRESH_THRESHOLD )); then
         echo "github-app: token valid, but close to expiration, refreshing in the background" >&2
         "$BIN_DIR/token-check.sh" --quiet 2>/dev/null &
         disown

--- a/plugins/github-app/hooks/scripts/github-token-init.sh
+++ b/plugins/github-app/hooks/scripts/github-token-init.sh
@@ -227,6 +227,20 @@ if [[ -f "$META_FILE" ]]; then
   EXPIRES_AT=$(jq -r '.expires_at // empty' "$META_FILE" 2>/dev/null)
 fi
 
+# --- GH_CONFIG_DIR isolation ---
+# Create an agent-specific, empty gh config directory so that gh never falls
+# back to the handler's personal keyring when the App token expires.
+# The directory is scoped to the agent (using CLAUDE_PROJECT_DIR if available,
+# otherwise HOME/.config/agent) so multiple agents don't share config.
+
+hook_log_step "gh-config-dir" "Creating isolated GH_CONFIG_DIR"
+
+_GH_CONFIG_SCOPE="${CLAUDE_PROJECT_DIR:-$HOME}"
+GH_CONFIG_DIR="${_GH_CONFIG_SCOPE}/.claude/tmp/gh-config"
+mkdir -p "$GH_CONFIG_DIR"
+chmod 700 "$GH_CONFIG_DIR"
+hook_log "GH_CONFIG_DIR isolated at $GH_CONFIG_DIR"
+
 # --- Write runtime env file ---
 # This file is sourced via CLAUDE_ENV_FILE so that subsequent Bash commands
 # always pick up the latest token. The PreToolUse hook updates this file
@@ -245,6 +259,7 @@ export GITHUB_APP_ID="$GITHUB_APP_ID"
 export GITHUB_APP_PRIVATE_KEY_PATH="$GITHUB_APP_PRIVATE_KEY_PATH"
 export GITHUB_INSTALLATION_ID="$GITHUB_INSTALLATION_ID"
 export GITHUB_APP_ENV_FILE="$ENV_RUNTIME_FILE"
+export GH_CONFIG_DIR="$GH_CONFIG_DIR"
 ENVEOF
 [[ -n "${GITHUB_APP_CLIENT_ID:-}" ]] && echo "export GITHUB_APP_CLIENT_ID=\"$GITHUB_APP_CLIENT_ID\"" >> "$ENV_RUNTIME_FILE"
 [[ -n "${GITHUB_APP_CLIENT_SECRET:-}" ]] && echo "export GITHUB_APP_CLIENT_SECRET=\"$GITHUB_APP_CLIENT_SECRET\"" >> "$ENV_RUNTIME_FILE"


### PR DESCRIPTION
## Summary

- **Fix 1 – GH_CONFIG_DIR isolation**: On SessionStart, create an agent-scoped empty `gh` config directory (`<project>/.claude/tmp/gh-config/`) and export `GH_CONFIG_DIR` into the runtime env file. This prevents `gh` from falling back to the handler's personal keyring when the App token expires. The isolation is preserved across token refreshes (`token-check.sh`).

- **Fix 2 – Proactive token refresh at 45 min**: GitHub App installation tokens expire after 1 hour. The PreToolUse hook previously started background refresh only at 30 minutes remaining. Raising the threshold to 45 minutes gives a full 45-minute buffer for the background refresh to complete before a token-using command fails.

## Changes

| File | Change |
|------|--------|
| `plugins/github-app/hooks/scripts/github-token-init.sh` | Create `GH_CONFIG_DIR`, write it to runtime env file |
| `plugins/github-app/bin/token-check.sh` | Preserve `GH_CONFIG_DIR` on refresh; raise threshold to 45 min |
| `plugins/github-app/hooks/scripts/github-token-check.sh` | Raise `REFRESH_THRESHOLD` to 45 min; add constant |

## Test plan

- [ ] Start a new session with the github-app plugin configured — verify `GH_CONFIG_DIR` is set in `~/.config/agent/github-app-env` and points to an empty agent-scoped directory
- [ ] Confirm `gh auth status` uses the App token and does not prompt for personal auth
- [ ] Simulate a near-expiry token (manually set `expires_at` in `.meta` to ~44 min from now) — confirm background refresh triggers on next `gh`/`git` Bash command
- [ ] Confirm refresh preserves `GH_CONFIG_DIR` in the runtime env file

Co-Authored-By: Jack Oat <jack-nsheaps[bot]@users.noreply.github.com>