### PR TITLE
fix(github-app): add op:// direct resolution + env file fallback

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -149,7 +149,7 @@
     {
       "name": "common-sense",
       "description": "Common-sense rules for AI assistant behavior. On session start, symlinks bundled rules into the project's .claude/rules/common-sense directory so they are automatically loaded as context.",
-      "version": "1.3.14",
+      "version": "1.3.15",
       "author": {
         "name": "Nathan Heaps"
       },
@@ -375,7 +375,7 @@
     {
       "name": "github-app",
       "description": "Automatic GitHub App token lifecycle for Claude Code sessions. Generates installation tokens on session start, monitors expiry via PreToolUse hook, and refreshes transparently before commands that need authentication.",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "Nathan Heaps"
       },

--- a/docs/hook-ordering.md
+++ b/docs/hook-ordering.md
@@ -1,0 +1,93 @@
+# Hook Ordering in Claude Code Plugins
+
+## Problem
+
+Claude Code does not guarantee the execution order of `SessionStart` hooks across plugins. When one plugin depends on environment variables injected by another plugin's hook, there is a race condition: the dependent plugin may run first and find the variables empty.
+
+**Example:** The `github-app` plugin needs `GITHUB_APP_ID`, `GITHUB_INSTALLATION_ID`, and `GITHUB_APP_PRIVATE_KEY_PATH` to generate a token. If the `1pass` plugin is responsible for injecting those values but runs after `github-app`, the `github-app` hook sees empty variables and silently skips token generation.
+
+## Why Polling Process Env Vars Doesn't Work
+
+Each SessionStart hook runs in its own subprocess. Env vars `export`ed inside one hook's subprocess are **never visible** to another hook's subprocess — subprocess environments are isolated by the OS.
+
+Polling `[[ -n "${VAR:-}" ]]` inside a hook will never observe values written by another hook's subprocess.
+
+## Pattern: `wait_for_env_file` via `CLAUDE_ENV_FILE`
+
+The correct mechanism is `CLAUDE_ENV_FILE` — a shared file that Claude Code sources before each Bash tool call. Plugins that need to share env vars write `export KEY=value` lines to this file. Other plugins can read (and source) this file to pick up those values.
+
+The `github-app` plugin provides a reusable helper at `lib/wait-for-env.sh` that polls `CLAUDE_ENV_FILE` for required variables with exponential backoff, then sources the file to make them available in the current process.
+
+### Usage
+
+```bash
+source "${CLAUDE_PLUGIN_ROOT}/lib/wait-for-env.sh"
+
+# Wait up to 15 seconds for credentials to appear in CLAUDE_ENV_FILE
+if wait_for_env_file GITHUB_APP_ID GITHUB_INSTALLATION_ID --timeout 15; then
+  echo "credentials available"
+else
+  echo "timed out — plugin not configured"
+  exit 0
+fi
+```
+
+### How It Works
+
+- Checks `CLAUDE_ENV_FILE` for `export VAR=value` lines matching each required variable
+- When all are found, sources the file to make vars available in the current process
+- Polls every 1 second, doubling the interval up to a maximum of 4 seconds
+- Returns `0` when all specified variables are found and sourced
+- Returns `1` if `CLAUDE_ENV_FILE` is not set or the timeout expires
+- Guard-loaded (safe to `source` multiple times via `_WAIT_FOR_ENV_LOADED`)
+
+### Recommended Timeouts
+
+| Hook type    | Timeout | Rationale                                    |
+| ------------ | ------- | -------------------------------------------- |
+| SessionStart | 15s     | Startup allows more wait time                |
+| PreToolUse   | 5s      | Per-tool hooks have a tighter latency budget |
+
+## Where to Apply This Pattern
+
+Apply `wait_for_env_file` in a plugin's `SessionStart` hook **before** the credentials check that exits early. The wait should only trigger if the variables are currently unset — if they are already present (e.g., from a user's shell environment), skip the wait entirely.
+
+```bash
+# Only wait if credentials aren't already in the environment
+if [[ -z "${REQUIRED_VAR:-}" ]]; then
+  source "${CLAUDE_PLUGIN_ROOT}/lib/wait-for-env.sh"
+  if wait_for_env_file REQUIRED_VAR --timeout 15; then
+    log "credentials became available after waiting for another plugin"
+  else
+    log "timeout — plugin not configured, skipping"
+    exit 0
+  fi
+fi
+```
+
+## Example: `github-app` + `1pass`
+
+The `1pass` plugin writes GitHub App secrets as `export KEY=value` lines to `CLAUDE_ENV_FILE`. When both plugins are enabled:
+
+1. Claude Code starts both `SessionStart` hooks concurrently (order unspecified)
+2. If `github-app` runs first, it finds empty env vars and enters the `wait_for_env_file` loop
+3. When `1pass` finishes writing to `CLAUDE_ENV_FILE`, `github-app`'s wait detects the lines, sources the file, and returns successfully
+4. Token generation proceeds normally
+
+If `1pass` is not configured or fails, the wait times out and `github-app` skips gracefully with a log message.
+
+## Plugin Author Guidelines
+
+- **Do not assume hook order.** Any plugin that depends on env vars from another plugin should use `wait_for_env_file`.
+- **Do not poll process env vars.** Each SessionStart hook is a separate subprocess; env vars exported by one subprocess are invisible to others.
+- **Use `CLAUDE_ENV_FILE` as the shared bus.** Write `export KEY=value` lines there; read them with `wait_for_env_file`.
+- **Keep the wait scoped.** Only wait for the specific variables you need, not for a general "ready" signal.
+- **Exit 0 on timeout.** Informational hooks should never block the session. Log a clear message and exit cleanly.
+- **Use shorter timeouts in PreToolUse.** PreToolUse hooks run before every tool call; excessive waiting degrades the user experience.
+- **Document your dependencies.** If your plugin requires another plugin to set specific env vars, document that in your `plugin.json` description or README.
+
+## Reference
+
+- `plugins/github-app/lib/wait-for-env.sh` — The reusable helper
+- `plugins/github-app/hooks/scripts/github-token-init.sh` — Usage in a SessionStart hook
+- `plugins/github-app/bin/token-check.sh` — Usage in a utility script (shorter timeout)

--- a/plugins/common-sense/.claude-plugin/plugin.json
+++ b/plugins/common-sense/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "common-sense",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "description": "Common-sense rules for AI assistant behavior. On session start, symlinks bundled rules into the project's .claude/rules/common-sense directory so they are automatically loaded as context.",
   "author": {
     "name": "Nathan Heaps",

--- a/plugins/github-app/.claude-plugin/plugin.json
+++ b/plugins/github-app/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-app",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Automatic GitHub App token lifecycle for Claude Code sessions. Generates installation tokens on session start, monitors expiry via PreToolUse hook, and refreshes transparently before commands that need authentication.",
   "author": {
     "name": "Nathan Heaps",

--- a/plugins/github-app/bin/token-check.sh
+++ b/plugins/github-app/bin/token-check.sh
@@ -169,9 +169,15 @@ do_refresh_with_retries() {
 
 # --- Main logic ---
 
-# Check credentials exist
+# Check credentials exist.
+# PreToolUse has a shorter time budget than SessionStart, so we use a 5s
+# wait here to handle the case where another plugin is still injecting
+# credentials (hook ordering race).
 if [[ -z "${GITHUB_APP_ID:-}" || -z "${GITHUB_APP_PRIVATE_KEY_PATH:-}" || -z "${GITHUB_INSTALLATION_ID:-}" ]]; then
-  exit 2
+  source "$PLUGIN_DIR/lib/resolve-secrets.sh"
+  if ! wait_for_env_file GITHUB_APP_ID GITHUB_APP_PRIVATE_KEY_PATH GITHUB_INSTALLATION_ID --timeout 5; then
+    exit 2
+  fi
 fi
 
 # Check cooldown

--- a/plugins/github-app/github-app.settings.yaml
+++ b/plugins/github-app/github-app.settings.yaml
@@ -15,8 +15,12 @@ github-app:
   # 1. ref: A URI that loads ALL secrets at once. Supported schemes:
   #
   #    op://vault/item
-  #      Fetches all fields from a 1Password item via nsheaps/op-exec.
-  #      Field labels become env var names (e.g., GITHUB_APP_ID).
+  #      Resolves all fields directly from a 1Password item using the op CLI.
+  #      Requires op to be installed and OP_SERVICE_ACCOUNT_TOKEN to be set
+  #      (injected by the agent launcher). Self-contained: does NOT require
+  #      the 1pass plugin. Field labels must match the expected env var names:
+  #      GITHUB_APP_ID, GITHUB_APP_CLIENT_ID, GITHUB_APP_CLIENT_SECRET,
+  #      GITHUB_APP_PRIVATE_KEY, GITHUB_INSTALLATION_ID.
   #      Example: ref: "op://vault/github-app--repo--my-repo"
   #
   #    env-file://path/to/file
@@ -29,6 +33,7 @@ github-app:
   #    - A literal value:         secrets.github_app_id: "12345"
   #    - An env var reference:    secrets.github_app_id: "${GITHUB_APP_ID}"
   #    - A 1Password field ref:   secrets.github_app_id: "op://vault/item/GITHUB_APP_ID"
+  #      (resolved directly via op CLI — no 1pass plugin needed)
   #    Individual secrets override ref values for the same field.
   #
   # 3. Environment variables: GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY_PATH, etc.
@@ -37,8 +42,8 @@ github-app:
   # 4. Legacy flat settings: github_app_id, private_key_path, github_installation_id
   #    Kept for backwards compatibility. Lowest priority.
 
-  # --- Option 1: Bulk secret reference ---
-  # ref: "op://vault/github-app--repo--my-repo"
+  # --- Option 1: Bulk secret reference (recommended) ---
+  # ref: "op://vault/github-app--repo--my-repo"   # Resolved directly via op CLI
   # ref: "env-file://./.env.github-app"
 
   # --- Option 2: Individual secrets ---

--- a/plugins/github-app/hooks/scripts/github-token-check.sh
+++ b/plugins/github-app/hooks/scripts/github-token-check.sh
@@ -44,9 +44,23 @@ if [[ -z "${GITHUB_APP_ID:-}" || -z "${GITHUB_APP_PRIVATE_KEY_PATH:-}" || -z "${
   exit 0
 fi
 
-# No token file means SessionStart didn't generate one — no opinion
+# No token file means SessionStart didn't generate one.
+# This can happen if SessionStart's wait timed out but credentials appeared
+# later (another plugin finished injecting them). If credentials are now
+# available, generate the token synchronously before proceeding.
 if [[ ! -f "$TOKEN_FILE" ]]; then
-  exit 0
+  if [[ -n "${GITHUB_APP_ID:-}" && -n "${GITHUB_APP_PRIVATE_KEY_PATH:-}" && -n "${GITHUB_INSTALLATION_ID:-}" ]]; then
+    echo "github-app: token file missing but credentials available, generating token now..." >&2
+    BIN_DIR_EARLY="${CLAUDE_PLUGIN_ROOT}/bin"
+    if "$BIN_DIR_EARLY/token-check.sh" --sync --quiet; then
+      : # Token generated — continue with the rest of the hook
+    else
+      echo "github-app: WARNING: on-demand token generation failed" >&2
+      exit 0
+    fi
+  else
+    exit 0
+  fi
 fi
 
 # --- Debounce/throttle ---

--- a/plugins/github-app/hooks/scripts/github-token-init.sh
+++ b/plugins/github-app/hooks/scripts/github-token-init.sh
@@ -6,10 +6,12 @@
 # an env-file to populate them before this hook runs.
 #
 # Supported secret sources via the `ref` setting:
+#   - op://vault/item         → resolve fields directly from 1Password (primary)
 #   - env-file://path/to/file → source KEY=VALUE pairs from a file
 # Individual secrets via `secrets.*`:
 #   - Literal values
 #   - ${VAR_NAME}             → expand from environment
+#   - op://vault/item/field   → resolve a single field from 1Password
 #
 # Required env vars (set directly or via ref/secrets config):
 #   GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY or GITHUB_APP_PRIVATE_KEY_PATH,
@@ -24,6 +26,7 @@ PLUGIN_NAME="github-app"
 source "${CLAUDE_PLUGIN_ROOT}/lib/plugin-config-read.sh"
 source "${CLAUDE_PLUGIN_ROOT}/lib/hook-logging.sh"
 source "${CLAUDE_PLUGIN_ROOT}/lib/agent-paths.sh"
+source "${CLAUDE_PLUGIN_ROOT}/lib/resolve-secrets.sh"
 
 # --- Guards ---
 
@@ -33,6 +36,7 @@ plugin_is_enabled || { hook_log "plugin disabled, skipping"; hook_respond; exit 
 
 # Resolve a secret value from one of:
 #   - ${VAR_NAME}  → expand from environment
+#   - op://...     → resolve from 1Password directly
 #   - literal      → use as-is
 resolve_secret() {
   local raw="$1"
@@ -53,6 +57,24 @@ resolve_secret() {
     fi
     echo "$resolved"
     return
+  fi
+
+  # 1Password reference: op://vault/item/field
+  if [[ "$raw" == op://* ]]; then
+    if _op_available; then
+      local resolved
+      resolved=$(op read "$raw" 2>/dev/null) || {
+        hook_log "WARNING: Failed to resolve $name from 1Password ($raw)"
+        echo ""
+        return
+      }
+      echo "$resolved"
+      return
+    else
+      hook_log "WARNING: op:// reference for $name but op CLI not available or OP_SERVICE_ACCOUNT_TOKEN not set"
+      echo ""
+      return
+    fi
   fi
 
   # Literal value
@@ -84,7 +106,21 @@ hook_log_step "load-secrets" "Loading secrets from configured source"
 REF="$(plugin_get_config "ref" "")"
 
 if [[ -n "$REF" ]]; then
-  if [[ "$REF" == env-file://* ]]; then
+  if [[ "$REF" == op://* ]]; then
+    # 1Password item reference — resolve all fields directly
+    if _op_available; then
+      hook_log "Resolving secrets directly from 1Password: $REF"
+      GITHUB_APP_ID="${GITHUB_APP_ID:-$(op read "${REF}/GITHUB_APP_ID" 2>/dev/null || true)}"
+      GITHUB_APP_CLIENT_ID="${GITHUB_APP_CLIENT_ID:-$(op read "${REF}/GITHUB_APP_CLIENT_ID" 2>/dev/null || true)}"
+      GITHUB_APP_CLIENT_SECRET="${GITHUB_APP_CLIENT_SECRET:-$(op read "${REF}/GITHUB_APP_CLIENT_SECRET" 2>/dev/null || true)}"
+      GITHUB_APP_PRIVATE_KEY="${GITHUB_APP_PRIVATE_KEY:-$(op read "${REF}/GITHUB_APP_PRIVATE_KEY" 2>/dev/null || true)}"
+      GITHUB_INSTALLATION_ID="${GITHUB_INSTALLATION_ID:-$(op read "${REF}/GITHUB_INSTALLATION_ID" 2>/dev/null || true)}"
+      hook_log "Resolved secrets from 1Password item"
+    else
+      hook_log "op:// ref configured but op CLI not available or OP_SERVICE_ACCOUNT_TOKEN not set"
+    fi
+
+  elif [[ "$REF" == env-file://* ]]; then
     # Env file reference — source KEY=VALUE pairs
     ENV_FILE_PATH="$(resolve_env_file_path "$REF")"
 
@@ -118,7 +154,7 @@ if [[ -n "$REF" ]]; then
 
   else
     hook_fail "ref config" "Unsupported ref format: $REF" \
-      "Use env-file:///path/to/file format. For 1Password secrets, configure the 1pass plugin to expose them as environment variables instead."
+      "Use op://vault/item or env-file:///path/to/file format."
     hook_respond; exit 0
   fi
 fi
@@ -154,6 +190,33 @@ fi
 # Fall back to legacy flat settings for backwards compatibility
 GITHUB_APP_ID="${GITHUB_APP_ID:-$(plugin_get_config "github_app_id" "")}"
 GITHUB_INSTALLATION_ID="${GITHUB_INSTALLATION_ID:-$(plugin_get_config "github_installation_id" "")}"
+
+# --- Wait for credentials (hook ordering fallback) ---
+#
+# Claude Code doesn't guarantee SessionStart hook execution order.
+# Primary path: credentials resolved via op:// ref or secrets.* config above.
+# Fallback path: poll CLAUDE_ENV_FILE in case another plugin (e.g., 1pass)
+# writes them there. The wait runs before private-key resolution so that
+# GITHUB_APP_PRIVATE_KEY (inline content) can still be written to a temp
+# file if it arrives late.
+
+if [[ -z "${GITHUB_APP_ID:-}" || -z "${GITHUB_INSTALLATION_ID:-}" ]]; then
+  hook_log "credentials not yet available, checking CLAUDE_ENV_FILE..."
+  if wait_for_env_file GITHUB_APP_ID GITHUB_INSTALLATION_ID --timeout 15; then
+    # Check for private key (value or path)
+    if wait_for_env_file GITHUB_APP_PRIVATE_KEY_PATH --timeout 2 || wait_for_env_file GITHUB_APP_PRIVATE_KEY --timeout 2; then
+      hook_log "credentials found in CLAUDE_ENV_FILE"
+    else
+      hook_log "timeout waiting for private key — GitHub App not configured, skipping"
+      hook_log_cleanup
+      hook_respond; exit 0
+    fi
+  else
+    hook_log "timeout waiting for credentials — GitHub App not configured, skipping"
+    hook_log_cleanup
+    hook_respond; exit 0
+  fi
+fi
 
 # --- Handle private key (value vs file path) ---
 

--- a/plugins/github-app/lib/resolve-secrets.sh
+++ b/plugins/github-app/lib/resolve-secrets.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# resolve-secrets.sh — Resolve op:// references and wait for env file fallback
+#
+# Provides two mechanisms for cross-plugin secret resolution:
+#
+# 1. Direct op:// resolution: If `op` is installed and OP_SERVICE_ACCOUNT_TOKEN
+#    is set, resolve op:// references directly without depending on 1pass plugin.
+#
+# 2. CLAUDE_ENV_FILE fallback: Poll the shared env file for required variables
+#    to appear (written by another plugin's SessionStart hook).
+#
+# Usage:
+#   source "${CLAUDE_PLUGIN_ROOT}/lib/resolve-secrets.sh"
+#
+#   # Try to resolve an op:// reference
+#   value=$(resolve_op_ref "op://vault/item/field")
+#
+#   # Wait for vars to appear in CLAUDE_ENV_FILE, then source it
+#   wait_for_env_file GITHUB_APP_ID GITHUB_INSTALLATION_ID --timeout 15
+
+[[ -n "${_RESOLVE_SECRETS_LOADED:-}" ]] && return 0
+_RESOLVE_SECRETS_LOADED=1
+
+# Check if op CLI is available and authenticated
+_op_available() {
+  command -v op >/dev/null 2>&1 && [[ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]
+}
+
+# Resolve an op:// reference to its value
+# Returns 0 and prints the value on success, 1 on failure
+resolve_op_ref() {
+  local ref="$1"
+  if ! _op_available; then
+    return 1
+  fi
+  op read "$ref" 2>/dev/null
+}
+
+# Wait for env vars to appear in CLAUDE_ENV_FILE, then source it
+wait_for_env_file() {
+  local timeout=15
+  local vars=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --timeout) timeout="$2"; shift 2 ;;
+      *) vars+=("$1"); shift ;;
+    esac
+  done
+
+  [[ ${#vars[@]} -eq 0 ]] && return 0
+
+  local env_file="${CLAUDE_ENV_FILE:-}"
+  if [[ -z "$env_file" ]]; then
+    return 1  # No env file mechanism available
+  fi
+
+  local elapsed=0
+  local interval=1
+  local max_interval=4
+
+  while (( elapsed < timeout )); do
+    if [[ -f "$env_file" ]]; then
+      # Check if all required vars are exported in the file
+      local all_found=true
+      for var in "${vars[@]}"; do
+        if ! grep -q "^export ${var}=" "$env_file" 2>/dev/null; then
+          all_found=false
+          break
+        fi
+      done
+
+      if [[ "$all_found" == "true" ]]; then
+        # Source the file to make vars available in this process
+        # shellcheck disable=SC1090
+        source "$env_file"
+        return 0
+      fi
+    fi
+
+    sleep "$interval"
+    elapsed=$(( elapsed + interval ))
+    interval=$(( interval * 2 ))
+    (( interval > max_interval )) && interval=$max_interval
+  done
+
+  return 1
+}


### PR DESCRIPTION
## Summary
Self-contained secret resolution for the github-app plugin. Resolves `op://` references directly without depending on 1pass plugin hook ordering.

- New `lib/resolve-secrets.sh`: generic `op://` resolver + `CLAUDE_ENV_FILE` poller
- SessionStart hook resolves `op://` refs from plugin config settings
- PreToolUse hook generates token if startup missed (fallback)
- `docs/hook-ordering.md`: pattern guide for plugin authors
- Version bump to 0.3.0

## Testing
Tested on Henry — confirmed working with `op://Agent-Henry/github--app--henry` ref. Token generated as `henry-nsheaps[bot]` with correct per-agent config dir.

## Related
- Supersedes #424 (closed due to squash merge conflicts)
- Builds on #410 (merged)

Co-Authored-By: Jack Oat (https://github.com/nsheaps/.ai-agent-jack) <jack-nsheaps[bot]@users.noreply.github.com>