### PR TITLE
feat(agentic-behavior): add work-tracking rules + spec/project management skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -626,7 +626,7 @@
     {
       "name": "sdlc-utils",
       "description": "Software development lifecycle utilities — skills organized by SDLC phase: plan, implement, review, test, deploy, and maintain.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "Nathan Heaps"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,10 +62,8 @@
         "claude-code",
         "autonomy",
         "rules",
-        "issue-management",
-        "task-tracking",
-        "deduplication",
-        "github-issues"
+        "work-tracking",
+        "milestones"
       ]
     },
     {
@@ -643,7 +641,10 @@
         "testing",
         "deployment",
         "maintenance",
-        "software-engineering"
+        "software-engineering",
+        "github-issues",
+        "task-tracking",
+        "project-management"
       ]
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,7 +44,7 @@
     {
       "name": "agentic-behavior",
       "description": "Skills for configuring Claude Code, behavior correction, memory tracking, autonomy rules, and time-context awareness. Combines prompt history tracking, git-backed memory sync, and the self-checking Ralph loop pattern.",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "author": {
         "name": "Nathan Heaps"
       },

--- a/plugins/agentic-behavior/.claude-plugin/plugin.json
+++ b/plugins/agentic-behavior/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-behavior",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Skills for configuring Claude Code, behavior correction, memory tracking, autonomy rules, and time-context awareness. Combines prompt history tracking, git-backed memory sync, and the self-checking Ralph loop pattern.",
   "author": {
     "name": "Nathan Heaps",

--- a/plugins/agentic-behavior/.claude-plugin/plugin.json
+++ b/plugins/agentic-behavior/.claude-plugin/plugin.json
@@ -18,10 +18,8 @@
     "claude-code",
     "autonomy",
     "rules",
-    "issue-management",
-    "task-tracking",
-    "deduplication",
-    "github-issues"
+    "work-tracking",
+    "milestones"
   ],
   "homepage": "https://github.com/nsheaps/ai-mktpl/tree/main/plugins/agentic-behavior",
   "repository": "https://github.com/nsheaps/ai-mktpl"

--- a/plugins/agentic-behavior/README.md
+++ b/plugins/agentic-behavior/README.md
@@ -24,6 +24,14 @@ Git-backed memory and prompt tracking with self-checking reminders (see `skills/
 
 Create, search, update, and link tickets across ticketing systems with a strong deduplication-first workflow. Always checks for existing issues before creating new ones (see `skills/issue-management/SKILL.md`).
 
+### /spec-management
+
+Manage specification documents co-located with plugins. Covers the spec lifecycle (draft through archive), combined format with Given/When/Then acceptance criteria, and the rule that every plugin change PR must include a spec update (see `skills/spec-management/SKILL.md`).
+
+### /github-issues-task-management
+
+Methodology for organizing work via GitHub Issues and Projects. Covers issue lifecycle, PR-to-issue linking, label conventions, consolidation strategy, and cross-repo references (see `skills/github-issues-task-management/SKILL.md`).
+
 ## Rules
 
 ### autonomy.md

--- a/plugins/agentic-behavior/README.md
+++ b/plugins/agentic-behavior/README.md
@@ -28,10 +28,6 @@ Create, search, update, and link tickets across ticketing systems with a strong 
 
 Manage specification documents co-located with plugins. Covers the spec lifecycle (draft through archive), combined format with Given/When/Then acceptance criteria, and the rule that every plugin change PR must include a spec update (see `skills/spec-management/SKILL.md`).
 
-### /github-issues-task-management
-
-Methodology for organizing work via GitHub Issues and Projects. Covers issue lifecycle, PR-to-issue linking, label conventions, consolidation strategy, and cross-repo references (see `skills/github-issues-task-management/SKILL.md`).
-
 ## Rules
 
 ### autonomy.md
@@ -40,7 +36,7 @@ Rules for autonomous decision-making, recommendation style, merge approval, and 
 
 ### work-tracking.md
 
-Rules for how tasks, PRs, milestones, and communication threads relate to each other. Covers thread ownership by role (SE vs PM), linking requirements (task thread → GitHub issue → milestone), thread discipline (first message as source of truth), and milestone management.
+Platform-agnostic rules for how tasks, PRs, and milestones relate to each other. Covers linking requirements (work items to milestones, PRs to work items), status tracking, and milestone management. Concrete implementations (GitHub Issues, Linear, etc.) are provided by separate skills in appropriate plugins.
 
 ## Features
 

--- a/plugins/agentic-behavior/README.md
+++ b/plugins/agentic-behavior/README.md
@@ -30,6 +30,10 @@ Create, search, update, and link tickets across ticketing systems with a strong 
 
 Rules for autonomous decision-making, recommendation style, merge approval, and research-first patterns. Synced into project `.claude/rules/` via the SessionStart hook.
 
+### work-tracking.md
+
+Rules for how tasks, PRs, milestones, and communication threads relate to each other. Covers thread ownership by role (SE vs PM), linking requirements (task thread → GitHub issue → milestone), thread discipline (first message as source of truth), and milestone management.
+
 ## Features
 
 ### Prompt History Tracking

--- a/plugins/agentic-behavior/rules/work-tracking.md
+++ b/plugins/agentic-behavior/rules/work-tracking.md
@@ -64,7 +64,7 @@ When a task moves milestones:
 
 ## Definitions
 
-- **task thread** — A Discord forum thread in the #tasks channel (ID: `1490930156553109708`) that tracks a specific unit of work. Each thread has a title prefix (`feat:`, `fix:`, etc.) and a first-message that serves as the canonical state.
+- **task thread** — A forum thread in the designated tasks channel that tracks a specific unit of work. Each thread has a title prefix (`feat:`, `fix:`, etc.) and a first-message that serves as the canonical state. The specific channel is project-dependent.
 - **handler** — The human operator who manages and directs the AI agent. The handler provides direction, approves merges, and makes final decisions. In this context, this is typically the repository owner.
 
 ## Source

--- a/plugins/agentic-behavior/rules/work-tracking.md
+++ b/plugins/agentic-behavior/rules/work-tracking.md
@@ -1,0 +1,55 @@
+# Work Tracking Rules
+
+Cross-cutting rules for how tasks, PRs, milestones, and communication threads relate to each other.
+
+## 1. Thread Ownership by Role
+
+- **Task threads** — created by the SE (software engineer) agent. Track active work: testing, reviews, PRs, research, coordination.
+- **Milestone threads** — created by the PM agent. Track milestone/project status and communicate overall progress to the handler.
+
+## 2. Linking Requirements
+
+### Every task thread MUST link to a milestone
+When the SE creates a task thread, it must be linked to a milestone thread. If no milestone exists, coordinate with the PM to create one or assign to an existing one.
+
+### Every PR MUST link to a task thread + GitHub issue + milestone
+When a PR is created, ensure all three exist:
+1. A task thread tracking the work
+2. A GitHub issue for coordination
+3. A milestone thread
+
+If any don't exist, coordinate with the PM to create them.
+
+### PRs MUST be developed against merged specs
+- Specs live on default branches in the relevant repos
+- Issues are coordination ground ("tickets to assign"), NOT the source of truth for specs
+- All specs should be merged (and reviewed if required) before PR work begins
+
+## 3. Thread Discipline
+
+### First message = source of truth
+The first message in any thread (task or milestone) is always the canonical state. Discussion within the thread should result in updating the first message:
+- Task threads: update CI status, mergeability, PR state, "last checked" timestamp
+- Milestone threads: update completion status of constituent tasks
+
+### Respond in the correct thread
+If the handler asks about something in a thread that isn't the right thread for the answer:
+1. Post the response in the correct thread
+2. Tag the handler in that thread
+3. Reply to the handler's original message with a link to the response
+
+### Milestone threads = status; Task threads = work
+- Milestone threads communicate STATUS to the handler (what's done, what's left)
+- Task threads coordinate WORK (testing, reviews, iteration, research)
+- Work updates post to task threads; phase completion posts to milestone threads
+
+## 4. Moving Tasks Between Milestones
+
+When a task moves milestones:
+1. Update the OLD milestone thread (remove/mark as moved)
+2. Update the NEW milestone thread (add the task)
+3. Both updates should be in the first message of each thread
+
+## Source
+- https://discord.com/channels/1490863845252665415/1490890535878131792/1497248350947381399
+- https://discord.com/channels/1490863845252665415/1490890535878131792/1497248448125337793

--- a/plugins/agentic-behavior/rules/work-tracking.md
+++ b/plugins/agentic-behavior/rules/work-tracking.md
@@ -6,6 +6,8 @@ Cross-cutting rules for how tasks, PRs, milestones, and communication threads re
 
 ## 1. Thread Ownership by Role
 
+In multi-agent setups, thread ownership is split by role. In single-agent setups, the single agent owns all threads and fulfills both roles.
+
 - **Task threads** — created by the SE (software engineer) agent. Track active work: testing, reviews, PRs, research, coordination.
 - **Milestone threads** — created by the PM agent. Track milestone/project status and communicate overall progress to the handler.
 
@@ -28,7 +30,7 @@ If any don't exist, coordinate with the PM to create them.
 ### PRs MUST be developed against merged specs
 
 - Specs live on default branches in the relevant repos
-- Issues are coordination ground ("tickets to assign"), NOT the source of truth for specs (see `github-issues-task-management.md` for issue-tracking conventions)
+- Issues are coordination ground ("tickets to assign"), NOT the source of truth for specs (see the [`/github-issues-task-management` skill](../skills/github-issues-task-management/SKILL.md) for issue-tracking conventions)
 - All specs should be merged (and reviewed if required) before PR work begins
 
 ## 3. Thread Discipline

--- a/plugins/agentic-behavior/rules/work-tracking.md
+++ b/plugins/agentic-behavior/rules/work-tracking.md
@@ -10,10 +10,13 @@ Cross-cutting rules for how tasks, PRs, milestones, and communication threads re
 ## 2. Linking Requirements
 
 ### Every task thread MUST link to a milestone
+
 When the SE creates a task thread, it must be linked to a milestone thread. If no milestone exists, coordinate with the PM to create one or assign to an existing one.
 
 ### Every PR MUST link to a task thread + GitHub issue + milestone
+
 When a PR is created, ensure all three exist:
+
 1. A task thread tracking the work
 2. A GitHub issue for coordination
 3. A milestone thread
@@ -21,6 +24,7 @@ When a PR is created, ensure all three exist:
 If any don't exist, coordinate with the PM to create them.
 
 ### PRs MUST be developed against merged specs
+
 - Specs live on default branches in the relevant repos
 - Issues are coordination ground ("tickets to assign"), NOT the source of truth for specs
 - All specs should be merged (and reviewed if required) before PR work begins
@@ -28,17 +32,22 @@ If any don't exist, coordinate with the PM to create them.
 ## 3. Thread Discipline
 
 ### First message = source of truth
+
 The first message in any thread (task or milestone) is always the canonical state. Discussion within the thread should result in updating the first message:
+
 - Task threads: update CI status, mergeability, PR state, "last checked" timestamp
 - Milestone threads: update completion status of constituent tasks
 
 ### Respond in the correct thread
+
 If the handler asks about something in a thread that isn't the right thread for the answer:
+
 1. Post the response in the correct thread
 2. Tag the handler in that thread
 3. Reply to the handler's original message with a link to the response
 
 ### Milestone threads = status; Task threads = work
+
 - Milestone threads communicate STATUS to the handler (what's done, what's left)
 - Task threads coordinate WORK (testing, reviews, iteration, research)
 - Work updates post to task threads; phase completion posts to milestone threads
@@ -46,10 +55,12 @@ If the handler asks about something in a thread that isn't the right thread for 
 ## 4. Moving Tasks Between Milestones
 
 When a task moves milestones:
+
 1. Update the OLD milestone thread (remove/mark as moved)
 2. Update the NEW milestone thread (add the task)
 3. Both updates should be in the first message of each thread
 
 ## Source
+
 - https://discord.com/channels/1490863845252665415/1490890535878131792/1497248350947381399
 - https://discord.com/channels/1490863845252665415/1490890535878131792/1497248448125337793

--- a/plugins/agentic-behavior/rules/work-tracking.md
+++ b/plugins/agentic-behavior/rules/work-tracking.md
@@ -62,6 +62,11 @@ When a task moves milestones:
 2. Update the NEW milestone thread (add the task)
 3. Both updates should be in the first message of each thread
 
+## Definitions
+
+- **task thread** — A Discord forum thread in the #tasks channel (ID: `1490930156553109708`) that tracks a specific unit of work. Each thread has a title prefix (`feat:`, `fix:`, etc.) and a first-message that serves as the canonical state.
+- **handler** — The human operator who manages and directs the AI agent. The handler provides direction, approves merges, and makes final decisions. In this context, this is typically the repository owner.
+
 ## Source
 
 - [Thread ownership and linking requirements](https://discord.com/channels/1490863845252665415/1490890535878131792/1497248350947381399)

--- a/plugins/agentic-behavior/rules/work-tracking.md
+++ b/plugins/agentic-behavior/rules/work-tracking.md
@@ -2,6 +2,8 @@
 
 Cross-cutting rules for how tasks, PRs, milestones, and communication threads relate to each other.
 
+> **Applicability:** These rules assume a multi-agent setup with coordinating roles (SE, PM, etc.). In single-agent setups, treat "thread" as the handler's primary communication surface (e.g., a Discord channel or Telegram chat).
+
 ## 1. Thread Ownership by Role
 
 - **Task threads** — created by the SE (software engineer) agent. Track active work: testing, reviews, PRs, research, coordination.
@@ -26,7 +28,7 @@ If any don't exist, coordinate with the PM to create them.
 ### PRs MUST be developed against merged specs
 
 - Specs live on default branches in the relevant repos
-- Issues are coordination ground ("tickets to assign"), NOT the source of truth for specs
+- Issues are coordination ground ("tickets to assign"), NOT the source of truth for specs (see `github-issues-task-management.md` for issue-tracking conventions)
 - All specs should be merged (and reviewed if required) before PR work begins
 
 ## 3. Thread Discipline
@@ -62,5 +64,5 @@ When a task moves milestones:
 
 ## Source
 
-- https://discord.com/channels/1490863845252665415/1490890535878131792/1497248350947381399
-- https://discord.com/channels/1490863845252665415/1490890535878131792/1497248448125337793
+- [Thread ownership and linking requirements](https://discord.com/channels/1490863845252665415/1490890535878131792/1497248350947381399)
+- [Thread discipline and milestone moves](https://discord.com/channels/1490863845252665415/1490890535878131792/1497248448125337793)

--- a/plugins/agentic-behavior/rules/work-tracking.md
+++ b/plugins/agentic-behavior/rules/work-tracking.md
@@ -1,75 +1,52 @@
 # Work Tracking Rules
 
-Cross-cutting rules for how tasks, PRs, milestones, and communication threads relate to each other.
+Cross-cutting rules for how tasks, PRs, milestones, and project management artifacts relate to each other.
 
-> **Applicability:** These rules assume a multi-agent setup with coordinating roles (SE, PM, etc.). In single-agent setups, treat "thread" as the handler's primary communication surface (e.g., a Discord channel or Telegram chat).
+> **Applicability:** These rules are platform-agnostic. Concrete implementations (GitHub Issues, Linear, file-based tracking) are provided by separate skills in appropriate plugins. These rules define the abstract relationships and constraints that any implementation must satisfy.
 
-## 1. Thread Ownership by Role
+## 1. Linking Requirements
 
-In multi-agent setups, thread ownership is split by role. In single-agent setups, the single agent owns all threads and fulfills both roles.
+### Every work item MUST link to a milestone
 
-- **Task threads** — created by the SE (software engineer) agent. Track active work: testing, reviews, PRs, research, coordination.
-- **Milestone threads** — created by the PM agent. Track milestone/project status and communicate overall progress to the handler.
+When creating a tracked work item, it must be linked to a milestone or project. If no milestone exists, coordinate with the appropriate role (PM, handler) to create one or assign to an existing one.
 
-## 2. Linking Requirements
+### Every PR MUST link to a work item + milestone
 
-### Every task thread MUST link to a milestone
+When a PR is created, ensure both exist:
 
-When the SE creates a task thread, it must be linked to a milestone thread. If no milestone exists, coordinate with the PM to create one or assign to an existing one.
+1. A tracked work item (issue, ticket, task) for coordination
+2. A milestone or project for status rollup
 
-### Every PR MUST link to a task thread + GitHub issue + milestone
-
-When a PR is created, ensure all three exist:
-
-1. A task thread tracking the work
-2. A GitHub issue for coordination
-3. A milestone thread
-
-If any don't exist, coordinate with the PM to create them.
+If either is missing, create them or coordinate to have them created.
 
 ### PRs MUST be developed against merged specs
 
 - Specs live on default branches in the relevant repos
-- Issues are coordination ground ("tickets to assign"), NOT the source of truth for specs (see the [`/github-issues-task-management` skill](../skills/github-issues-task-management/SKILL.md) for issue-tracking conventions)
+- Work items are coordination ground ("tickets to assign"), NOT the source of truth for specs
 - All specs should be merged (and reviewed if required) before PR work begins
 
-## 3. Thread Discipline
+## 2. Status Tracking
 
-### First message = source of truth
+### Canonical state lives in the tracking system
 
-The first message in any thread (task or milestone) is always the canonical state. Discussion within the thread should result in updating the first message:
+The primary record of a work item's status lives in the project management tool (issues, boards, milestones). Communication channels supplement but do not replace the canonical tracking.
 
-- Task threads: update CI status, mergeability, PR state, "last checked" timestamp
-- Milestone threads: update completion status of constituent tasks
+### Status updates flow upward
 
-### Respond in the correct thread
+- Work-level updates belong on the work item (PR status, test results, review state)
+- Milestone-level updates belong on the milestone (which work items are done, what is left)
+- Status communication to stakeholders summarizes from the canonical records
 
-If the handler asks about something in a thread that isn't the right thread for the answer:
-
-1. Post the response in the correct thread
-2. Tag the handler in that thread
-3. Reply to the handler's original message with a link to the response
-
-### Milestone threads = status; Task threads = work
-
-- Milestone threads communicate STATUS to the handler (what's done, what's left)
-- Task threads coordinate WORK (testing, reviews, iteration, research)
-- Work updates post to task threads; phase completion posts to milestone threads
-
-## 4. Moving Tasks Between Milestones
+## 3. Moving Tasks Between Milestones
 
 When a task moves milestones:
 
-1. Update the OLD milestone thread (remove/mark as moved)
-2. Update the NEW milestone thread (add the task)
-3. Both updates should be in the first message of each thread
+1. Update the OLD milestone (remove or mark as moved)
+2. Update the NEW milestone (add the task)
+3. Both updates should be reflected in the canonical tracking system
 
 ## Definitions
 
-- **task thread** — A forum thread in the designated tasks channel that tracks a specific unit of work. Each thread has a title prefix (`feat:`, `fix:`, etc.) and a first-message that serves as the canonical state. The specific channel is project-dependent.
-- **handler** — The human operator who manages and directs the AI agent. The handler provides direction, approves merges, and makes final decisions. In this context, this is typically the repository owner.
-
-## Source
-
-- [Thread ownership and linking requirements](https://discord.com/channels/1490863845252665415/1490890535878131792/1497248350947381399)
-- [Thread discipline and milestone moves](https://discord.com/channels/1490863845252665415/1490890535878131792/1497248448125337793)
+- **work item** -- A trackable unit of work in the project management system (GitHub Issue, Linear ticket, checklist item, etc.). Has a title, status, and links to related artifacts.
+- **milestone** -- A collection of work items representing a project phase, sprint, or release goal. Provides rollup status visibility.
+- **handler** -- The human operator who manages and directs the AI agent. The handler provides direction, approves merges, and makes final decisions.

--- a/plugins/agentic-behavior/skills/github-issues-task-management/SKILL.md
+++ b/plugins/agentic-behavior/skills/github-issues-task-management/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: github-issues-task-management
+description: >
+  This skill should be used when organizing work via GitHub Issues and Projects,
+  creating project boards, managing milestones, or when transitioning from
+  Discord thread-based tracking to GitHub-native tracking. Trigger phrases:
+  "set up projects", "create a project board", "organize issues", "milestone
+  planning", "what issues need attention", "consolidate tickets".
+---
+
+# GitHub Issues Task Management
+
+GitHub Issues and Projects are the canonical system for tracking work. Discord
+threads are supplementary communication channels, not the source of truth for
+task status or assignments.
+
+## Core Principles
+
+1. **GitHub Issues are canonical.** Every significant work item needs a GitHub
+   Issue. If it is not in GitHub Issues, it is not tracked.
+2. **Consolidate, don't fragment.** Prefer fewer, broader issues over many
+   narrow ones. A single issue for "implement feature X" is better than five
+   issues for each sub-task unless the sub-tasks will be worked independently
+   by different people or across different PRs.
+3. **Discord supplements, not replaces.** Discord threads are for real-time
+   discussion, status pings, and coordination. The issue is where decisions,
+   acceptance criteria, and resolution are recorded.
+4. **Link everything.** PRs link to issues. Issues link to project boards.
+   Cross-repo references use full `owner/repo#N` format.
+
+## Issue Lifecycle
+
+### Creating Issues
+
+Every issue must have:
+
+- **Clear title** -- action-oriented, specific (not "Fix stuff")
+- **Body with context** -- what, why, and acceptance criteria
+- **Labels** -- at minimum a type label
+
+Use the `issue-management` skill for the mechanics of creating, searching, and
+updating issues via `gh` CLI. This skill covers the methodology.
+
+### Linking PRs to Issues
+
+Add magic phrases to the PR body to auto-close issues on merge:
+
+```markdown
+Fixes #42
+Fixes nsheaps/ai-mktpl#15
+Closes #7
+```
+
+Use `Fixes` for bug fixes, `Closes` for features/enhancements. For cross-repo
+links, always use the full `owner/repo#N` format.
+
+### Closing Issues
+
+Issues close automatically when a linked PR merges. If closing manually, always
+include a comment explaining resolution and referencing the relevant commit or
+PR.
+
+## Labels
+
+### Priority Labels
+
+| Label | Meaning |
+|---|---|
+| `p0` | Critical -- blocking all other work, fix immediately |
+| `p1` | High -- should be resolved this sprint/cycle |
+| `p2` | Normal -- important but not urgent |
+| `p3` | Low -- nice to have, backlog |
+
+### Type Labels
+
+| Label | Meaning |
+|---|---|
+| `bug` | Something is broken |
+| `enhancement` | Improvement to existing functionality |
+| `chore` | Maintenance, refactoring, tooling |
+| `question` | Needs discussion or clarification |
+
+### Status Labels (optional)
+
+Use sparingly -- GitHub Projects board columns often replace these:
+
+| Label | Meaning |
+|---|---|
+| `needs-triage` | Not yet prioritized |
+| `blocked` | Waiting on external dependency |
+| `in-progress` | Actively being worked |
+
+## GitHub Projects
+
+### When to Use Projects
+
+- Organizing work across multiple repos
+- Tracking milestones with multiple constituent issues
+- Providing stakeholder visibility into progress
+- Sprint or cycle planning
+
+### Project Board Setup
+
+```bash
+# Create a project (org-level)
+gh project create --owner nsheaps --title "Milestone: Feature X"
+
+# Add an issue to a project
+gh project item-add PROJECT_NUMBER --owner nsheaps --url https://github.com/nsheaps/repo/issues/42
+```
+
+### Board Columns
+
+Standard column layout:
+
+| Column | Purpose |
+|---|---|
+| Backlog | Triaged but not started |
+| In Progress | Actively being worked |
+| In Review | PR open, awaiting review |
+| Done | Merged and verified |
+
+## Consolidation Strategy
+
+When transitioning from fragmented tracking (many small Discord threads, many
+narrow issues) to consolidated GitHub tracking:
+
+### Step 1 -- Audit existing issues
+
+```bash
+gh issue list --repo owner/repo --state open --limit 100
+```
+
+### Step 2 -- Identify duplicates and related issues
+
+Group issues that track the same feature, bug, or initiative. Look for:
+
+- Same root cause described differently
+- Sub-tasks that belong under a parent issue
+- Issues that were superseded by newer ones
+
+### Step 3 -- Consolidate
+
+- Close duplicates with a comment linking to the canonical issue
+- Merge sub-tasks into a parent issue (add as checklist items in the body)
+- Transfer context from Discord threads into issue comments
+
+### Step 4 -- Organize into project
+
+- Create or update the relevant GitHub Project board
+- Add all canonical issues to the board
+- Set priorities and assignments
+
+## Cross-Repo Issue Linking
+
+When work spans multiple repos, always use full references:
+
+```markdown
+Related to nsheaps/agents#12
+Blocked by nsheaps/ai-mktpl#45
+Fixes nsheaps/ai-mktpl#15
+```
+
+Short references (`#N`) only work within the same repo. Cross-repo references
+require `owner/repo#N`.
+
+## Relationship to Other Skills
+
+| Skill | Scope |
+|---|---|
+| `issue-management` | Mechanics: how to create, search, update, close issues via CLI |
+| `github-issues-task-management` (this skill) | Methodology: how to organize work, manage projects, consolidate tracking |
+| `discord-work-tracking` | Discord-side patterns for threads that supplement GitHub Issues |
+
+## Anti-Patterns
+
+| Anti-Pattern | Instead |
+|---|---|
+| Tracking work only in Discord threads | Create a GitHub Issue; use Discord for discussion |
+| One issue per tiny sub-task | Consolidate into a parent issue with a checklist |
+| Short-form references across repos (`#N`) | Use `owner/repo#N` for cross-repo links |
+| No labels on issues | Add at least type + priority labels |
+| Closing issues without explanation | Comment with resolution and link to PR/commit |
+| Using issue body as a living document without history | Use comments for updates; keep body as canonical state |
+
+## References
+
+- [GitHub Issues documentation](https://docs.github.com/en/issues)
+- [GitHub Projects documentation](https://docs.github.com/en/issues/planning-and-tracking-with-projects)
+- [`issue-management` skill](../issue-management/SKILL.md) -- CLI mechanics for issue operations
+- [`gh` CLI skill](../../../github/skills/gh/SKILL.md) -- full gh CLI reference

--- a/plugins/agentic-behavior/skills/github-issues-task-management/SKILL.md
+++ b/plugins/agentic-behavior/skills/github-issues-task-management/SKILL.md
@@ -51,8 +51,16 @@ Fixes nsheaps/ai-mktpl#15
 Closes #7
 ```
 
-Use `Fixes` for bug fixes, `Closes` for features/enhancements. For cross-repo
-links, always use the full `owner/repo#N` format.
+**Semantic convention** (GitHub treats all linking keywords identically, but we
+use them to signal intent to human readers):
+
+- `Fixes` — the PR satisfies/resolves the issue described (bug fix, feature
+  implementation). The issue represents work that is now complete.
+- `Closes` — the PR supersedes or replaces another PR or issue without
+  necessarily implementing it (e.g., a rewrite that obsoletes an older PR, or
+  closing a duplicate).
+
+For cross-repo links, always use the full `owner/repo#N` format.
 
 ### Closing Issues
 

--- a/plugins/agentic-behavior/skills/github-issues-task-management/SKILL.md
+++ b/plugins/agentic-behavior/skills/github-issues-task-management/SKILL.md
@@ -70,33 +70,33 @@ defines as the single source of truth. The categories below are common conventio
 Common conventions include `p0`/`p1`/`p2`/`p3` or `priority:high`/`priority:low`.
 Check the project's `.github/labels.yaml` for the actual label names and use those.
 
-| Concept  | Meaning                                              |
-| -------- | ---------------------------------------------------- |
-| Critical | Blocking all other work, fix immediately             |
-| High     | Should be resolved this sprint/cycle                 |
-| Normal   | Important but not urgent                             |
-| Low      | Nice to have, backlog                                |
+| Concept  | Meaning                                  |
+| -------- | ---------------------------------------- |
+| Critical | Blocking all other work, fix immediately |
+| High     | Should be resolved this sprint/cycle     |
+| Normal   | Important but not urgent                 |
+| Low      | Nice to have, backlog                    |
 
 ### Type Labels
 
 Common type labels (exact names may differ per project):
 
-| Concept       | Meaning                               |
-| ------------- | ------------------------------------- |
-| bug           | Something is broken                   |
-| enhancement   | Improvement to existing functionality |
-| chore         | Maintenance, refactoring, tooling     |
-| question      | Needs discussion or clarification     |
+| Concept     | Meaning                               |
+| ----------- | ------------------------------------- |
+| bug         | Something is broken                   |
+| enhancement | Improvement to existing functionality |
+| chore       | Maintenance, refactoring, tooling     |
+| question    | Needs discussion or clarification     |
 
 ### Status Labels (optional)
 
 Use sparingly -- GitHub Projects board columns often replace these:
 
-| Concept        | Meaning                        |
-| -------------- | ------------------------------ |
-| needs-triage   | Not yet prioritized            |
-| blocked        | Waiting on external dependency |
-| in-progress    | Actively being worked          |
+| Concept      | Meaning                        |
+| ------------ | ------------------------------ |
+| needs-triage | Not yet prioritized            |
+| blocked      | Waiting on external dependency |
+| in-progress  | Actively being worked          |
 
 ## GitHub Projects
 
@@ -174,11 +174,11 @@ require `owner/repo#N`.
 
 ## Relationship to Other Skills
 
-| Skill / Rule                                             | Scope                                                                    |
-| -------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `issue-management`                                       | Mechanics: how to create, search, update, close issues via CLI           |
-| `github-issues-task-management` (this skill)             | Methodology: how to organize work, manage projects, consolidate tracking |
-| `agentic-behavior/rules/work-tracking.md`                | Thread-side discipline: linking, ownership, and milestone coordination   |
+| Skill / Rule                                 | Scope                                                                    |
+| -------------------------------------------- | ------------------------------------------------------------------------ |
+| `issue-management`                           | Mechanics: how to create, search, update, close issues via CLI           |
+| `github-issues-task-management` (this skill) | Methodology: how to organize work, manage projects, consolidate tracking |
+| `agentic-behavior/rules/work-tracking.md`    | Thread-side discipline: linking, ownership, and milestone coordination   |
 
 ## Anti-Patterns
 

--- a/plugins/agentic-behavior/skills/github-issues-task-management/SKILL.md
+++ b/plugins/agentic-behavior/skills/github-issues-task-management/SKILL.md
@@ -64,31 +64,31 @@ PR.
 
 ### Priority Labels
 
-| Label | Meaning |
-|---|---|
-| `p0` | Critical -- blocking all other work, fix immediately |
-| `p1` | High -- should be resolved this sprint/cycle |
-| `p2` | Normal -- important but not urgent |
-| `p3` | Low -- nice to have, backlog |
+| Label | Meaning                                              |
+| ----- | ---------------------------------------------------- |
+| `p0`  | Critical -- blocking all other work, fix immediately |
+| `p1`  | High -- should be resolved this sprint/cycle         |
+| `p2`  | Normal -- important but not urgent                   |
+| `p3`  | Low -- nice to have, backlog                         |
 
 ### Type Labels
 
-| Label | Meaning |
-|---|---|
-| `bug` | Something is broken |
+| Label         | Meaning                               |
+| ------------- | ------------------------------------- |
+| `bug`         | Something is broken                   |
 | `enhancement` | Improvement to existing functionality |
-| `chore` | Maintenance, refactoring, tooling |
-| `question` | Needs discussion or clarification |
+| `chore`       | Maintenance, refactoring, tooling     |
+| `question`    | Needs discussion or clarification     |
 
 ### Status Labels (optional)
 
 Use sparingly -- GitHub Projects board columns often replace these:
 
-| Label | Meaning |
-|---|---|
-| `needs-triage` | Not yet prioritized |
-| `blocked` | Waiting on external dependency |
-| `in-progress` | Actively being worked |
+| Label          | Meaning                        |
+| -------------- | ------------------------------ |
+| `needs-triage` | Not yet prioritized            |
+| `blocked`      | Waiting on external dependency |
+| `in-progress`  | Actively being worked          |
 
 ## GitHub Projects
 
@@ -113,12 +113,12 @@ gh project item-add PROJECT_NUMBER --owner nsheaps --url https://github.com/nshe
 
 Standard column layout:
 
-| Column | Purpose |
-|---|---|
-| Backlog | Triaged but not started |
-| In Progress | Actively being worked |
-| In Review | PR open, awaiting review |
-| Done | Merged and verified |
+| Column      | Purpose                  |
+| ----------- | ------------------------ |
+| Backlog     | Triaged but not started  |
+| In Progress | Actively being worked    |
+| In Review   | PR open, awaiting review |
+| Done        | Merged and verified      |
 
 ## Consolidation Strategy
 
@@ -166,21 +166,21 @@ require `owner/repo#N`.
 
 ## Relationship to Other Skills
 
-| Skill | Scope |
-|---|---|
-| `issue-management` | Mechanics: how to create, search, update, close issues via CLI |
+| Skill                                        | Scope                                                                    |
+| -------------------------------------------- | ------------------------------------------------------------------------ |
+| `issue-management`                           | Mechanics: how to create, search, update, close issues via CLI           |
 | `github-issues-task-management` (this skill) | Methodology: how to organize work, manage projects, consolidate tracking |
-| `discord-work-tracking` | Discord-side patterns for threads that supplement GitHub Issues |
+| `discord-work-tracking`                      | Discord-side patterns for threads that supplement GitHub Issues          |
 
 ## Anti-Patterns
 
-| Anti-Pattern | Instead |
-|---|---|
-| Tracking work only in Discord threads | Create a GitHub Issue; use Discord for discussion |
-| One issue per tiny sub-task | Consolidate into a parent issue with a checklist |
-| Short-form references across repos (`#N`) | Use `owner/repo#N` for cross-repo links |
-| No labels on issues | Add at least type + priority labels |
-| Closing issues without explanation | Comment with resolution and link to PR/commit |
+| Anti-Pattern                                          | Instead                                                |
+| ----------------------------------------------------- | ------------------------------------------------------ |
+| Tracking work only in Discord threads                 | Create a GitHub Issue; use Discord for discussion      |
+| One issue per tiny sub-task                           | Consolidate into a parent issue with a checklist       |
+| Short-form references across repos (`#N`)             | Use `owner/repo#N` for cross-repo links                |
+| No labels on issues                                   | Add at least type + priority labels                    |
+| Closing issues without explanation                    | Comment with resolution and link to PR/commit          |
 | Using issue body as a living document without history | Use comments for updates; keep body as canonical state |
 
 ## References

--- a/plugins/agentic-behavior/skills/github-issues-task-management/SKILL.md
+++ b/plugins/agentic-behavior/skills/github-issues-task-management/SKILL.md
@@ -62,33 +62,41 @@ PR.
 
 ## Labels
 
+Labels vary by project. Always conform to whatever the project's `.github/labels.yaml`
+defines as the single source of truth. The categories below are common conventions.
+
 ### Priority Labels
 
-| Label | Meaning                                              |
-| ----- | ---------------------------------------------------- |
-| `p0`  | Critical -- blocking all other work, fix immediately |
-| `p1`  | High -- should be resolved this sprint/cycle         |
-| `p2`  | Normal -- important but not urgent                   |
-| `p3`  | Low -- nice to have, backlog                         |
+Common conventions include `p0`/`p1`/`p2`/`p3` or `priority:high`/`priority:low`.
+Check the project's `.github/labels.yaml` for the actual label names and use those.
+
+| Concept  | Meaning                                              |
+| -------- | ---------------------------------------------------- |
+| Critical | Blocking all other work, fix immediately             |
+| High     | Should be resolved this sprint/cycle                 |
+| Normal   | Important but not urgent                             |
+| Low      | Nice to have, backlog                                |
 
 ### Type Labels
 
-| Label         | Meaning                               |
+Common type labels (exact names may differ per project):
+
+| Concept       | Meaning                               |
 | ------------- | ------------------------------------- |
-| `bug`         | Something is broken                   |
-| `enhancement` | Improvement to existing functionality |
-| `chore`       | Maintenance, refactoring, tooling     |
-| `question`    | Needs discussion or clarification     |
+| bug           | Something is broken                   |
+| enhancement   | Improvement to existing functionality |
+| chore         | Maintenance, refactoring, tooling     |
+| question      | Needs discussion or clarification     |
 
 ### Status Labels (optional)
 
 Use sparingly -- GitHub Projects board columns often replace these:
 
-| Label          | Meaning                        |
+| Concept        | Meaning                        |
 | -------------- | ------------------------------ |
-| `needs-triage` | Not yet prioritized            |
-| `blocked`      | Waiting on external dependency |
-| `in-progress`  | Actively being worked          |
+| needs-triage   | Not yet prioritized            |
+| blocked        | Waiting on external dependency |
+| in-progress    | Actively being worked          |
 
 ## GitHub Projects
 
@@ -166,11 +174,11 @@ require `owner/repo#N`.
 
 ## Relationship to Other Skills
 
-| Skill                                        | Scope                                                                    |
-| -------------------------------------------- | ------------------------------------------------------------------------ |
-| `issue-management`                           | Mechanics: how to create, search, update, close issues via CLI           |
-| `github-issues-task-management` (this skill) | Methodology: how to organize work, manage projects, consolidate tracking |
-| `discord-work-tracking`                      | Discord-side patterns for threads that supplement GitHub Issues          |
+| Skill / Rule                                             | Scope                                                                    |
+| -------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `issue-management`                                       | Mechanics: how to create, search, update, close issues via CLI           |
+| `github-issues-task-management` (this skill)             | Methodology: how to organize work, manage projects, consolidate tracking |
+| `agentic-behavior/rules/work-tracking.md`                | Thread-side discipline: linking, ownership, and milestone coordination   |
 
 ## Anti-Patterns
 

--- a/plugins/agentic-behavior/skills/spec-management/SKILL.md
+++ b/plugins/agentic-behavior/skills/spec-management/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: spec-management
+description: >
+  This skill should be used when creating, updating, or reviewing specifications
+  during the PR process. Trigger phrases: "write a spec", "update the spec",
+  "does this PR have a spec", "add a spec to this PR", "review the spec",
+  "spec-driven development", or when making plugin changes that need specification
+  documentation.
+---
+
+# Spec Management
+
+Specifications are natural-language descriptions of features that serve as the
+source of truth for PM, PO, QA, QE, and ops. Think of them as natural-language
+unit and integration tests -- they define what a feature does, why it exists, and
+how to verify it works.
+
+## Core Rules
+
+1. **Every plugin change PR must include a spec update in the same PR.** If a PR
+   changes plugin behavior, the corresponding spec must be created or updated as
+   part of that PR.
+2. **Specs are source of truth.** Code implements what the spec describes. If
+   code and spec disagree, the spec wins (update the code or update the spec
+   with approval).
+3. **PRs must be developed against merged specs.** Specs should exist on the
+   default branch before implementation starts. Exception: draft specs may be
+   included in the PR that implements the feature, but must be reviewed as part
+   of the PR.
+
+## Directory Structure
+
+Specs live co-located with the plugin they describe:
+
+```
+plugins/<plugin-name>/docs/specs/
+  draft/          # Initial drafts and brainstorming
+  reviewed/       # Reviewed and approved
+  in-progress/    # Currently being implemented
+  live/           # Finalized and actively in use
+  deprecated/     # Outdated but still referenced
+  archive/        # No longer in use
+```
+
+This follows the convention defined in `common-sense/rules/mantras-and-incremental-development.md`.
+
+## Spec Format
+
+Each spec is a single markdown file with YAML frontmatter, a reader guide, and
+content sections that mix narrative with testable Given/When/Then scenarios.
+
+### Frontmatter
+
+```yaml
+---
+title: "<Feature or Rule Name>"
+status: draft | reviewed | in-progress | live | deprecated | archived
+version: "0.1.0"
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+pr: "<owner/repo#N or URL>"  # PR that introduced or last updated this spec
+---
+```
+
+### Reader Guide
+
+Immediately after frontmatter, include a short section explaining who the spec
+is for and how to read it:
+
+```markdown
+## Reader Guide
+
+**Audience:** PM, PO, QA, QE, ops, and engineers implementing the feature.
+
+**How to read this spec:** Narrative sections describe intent and context.
+`Given/When/Then` blocks define testable acceptance criteria. If you are
+reviewing for correctness, focus on the Given/When/Then blocks.
+```
+
+### Content Sections
+
+Specs use a **combined format** -- Problem & Requirements (what and why) plus
+Technical Design (how) in a single document. Do NOT separate these into distinct
+"PRD" and "spec" documents.
+
+Typical sections:
+
+1. **Problem** -- What problem does this solve? Who is affected?
+2. **Requirements** -- What must be true for the feature to be complete?
+3. **Design** -- How does the implementation work? Key decisions and trade-offs.
+4. **Acceptance Criteria** -- Given/When/Then scenarios covering happy path,
+   edge cases, and error conditions.
+5. **References** -- Links to PRs, issues, discussions, or external docs.
+
+### Given/When/Then Format
+
+Use this format for testable criteria:
+
+```markdown
+### Scenario: <descriptive name>
+
+**Given** <precondition>
+**When** <action or trigger>
+**Then** <expected outcome>
+```
+
+Group related scenarios under a shared heading. Each scenario should be
+independently verifiable.
+
+## Size Guidelines
+
+- Aim to keep specs under ~500 lines.
+- If a spec grows beyond that, split into a **parent spec** (scope and
+  requirements) and **child specs** (technical details per component).
+- Child specs reference the parent via frontmatter or a "Parent Spec" section.
+
+## Workflow
+
+### Creating a new spec
+
+1. Create the file at `plugins/<plugin>/docs/specs/draft/<spec-name>.md`
+2. Fill in frontmatter with `status: draft`
+3. Write Problem, Requirements, and initial acceptance criteria
+4. Add the spec to the same PR as the implementation (or a preceding PR)
+
+### Updating an existing spec
+
+1. Find the current spec in its lifecycle directory (draft/reviewed/live/etc.)
+2. Update content and bump `updated` date in frontmatter
+3. If the spec moves lifecycle stages, move the file to the new directory
+4. Include the spec update in the same PR as the code change
+
+### Reviewing a spec
+
+When reviewing a PR that includes a spec:
+
+- Verify Given/When/Then scenarios cover happy path AND edge cases
+- Check that the spec matches what the code actually implements
+- Confirm the spec is understandable by non-engineers (PM/QA audiences)
+- Verify size is under ~500 lines; suggest splitting if larger
+
+## Anti-Patterns
+
+| Anti-Pattern | Instead |
+|---|---|
+| PR changes plugin behavior with no spec update | Include spec update in the same PR |
+| Separate PRD and technical spec documents | Use combined format in one file |
+| Spec only has narrative, no testable criteria | Add Given/When/Then acceptance criteria |
+| 800-line mega-spec | Split into parent + child specs |
+| Spec lives in a random location | Co-locate under `plugins/<name>/docs/specs/` |
+| Starting implementation before spec exists | Write at least a draft spec first |
+
+## References
+
+- [Spec directory conventions](../../../common-sense/rules/mantras-and-incremental-development.md) -- defines the draft/reviewed/in-progress/live/deprecated/archive lifecycle
+- [Handler feedback on specs](https://discord.com/channels/1490863845252665415/1490890535878131792/1497248350947381399) -- source discussion on spec requirements

--- a/plugins/agentic-behavior/skills/spec-management/SKILL.md
+++ b/plugins/agentic-behavior/skills/spec-management/SKILL.md
@@ -153,4 +153,4 @@ When reviewing a PR that includes a spec:
 ## References
 
 - [Spec directory conventions](../../../common-sense/rules/mantras-and-incremental-development.md) -- defines the draft/reviewed/in-progress/live/deprecated/archive lifecycle
-- [Handler feedback on specs](https://discord.com/channels/1490863845252665415/1490890535878131792/1497248350947381399) -- source discussion on spec requirements
+- Handler feedback on specs -- originated from org Discord discussion on requiring specs for every plugin change PR and developing PRs against merged specs

--- a/plugins/agentic-behavior/skills/spec-management/SKILL.md
+++ b/plugins/agentic-behavior/skills/spec-management/SKILL.md
@@ -153,4 +153,4 @@ When reviewing a PR that includes a spec:
 ## References
 
 - [Spec directory conventions](../../../common-sense/rules/mantras-and-incremental-development.md) -- defines the draft/reviewed/in-progress/live/deprecated/archive lifecycle
-- Handler feedback on specs -- originated from org Discord discussion on requiring specs for every plugin change PR and developing PRs against merged specs
+- Handler feedback on specs -- requiring specs for every plugin change PR and developing PRs against merged specs

--- a/plugins/agentic-behavior/skills/spec-management/SKILL.md
+++ b/plugins/agentic-behavior/skills/spec-management/SKILL.md
@@ -58,7 +58,7 @@ status: draft | reviewed | in-progress | live | deprecated | archived
 version: "0.1.0"
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
-pr: "<owner/repo#N or URL>"  # PR that introduced or last updated this spec
+pr: "<owner/repo#N or URL>" # PR that introduced or last updated this spec
 ---
 ```
 
@@ -141,14 +141,14 @@ When reviewing a PR that includes a spec:
 
 ## Anti-Patterns
 
-| Anti-Pattern | Instead |
-|---|---|
-| PR changes plugin behavior with no spec update | Include spec update in the same PR |
-| Separate PRD and technical spec documents | Use combined format in one file |
-| Spec only has narrative, no testable criteria | Add Given/When/Then acceptance criteria |
-| 800-line mega-spec | Split into parent + child specs |
-| Spec lives in a random location | Co-locate under `plugins/<name>/docs/specs/` |
-| Starting implementation before spec exists | Write at least a draft spec first |
+| Anti-Pattern                                   | Instead                                      |
+| ---------------------------------------------- | -------------------------------------------- |
+| PR changes plugin behavior with no spec update | Include spec update in the same PR           |
+| Separate PRD and technical spec documents      | Use combined format in one file              |
+| Spec only has narrative, no testable criteria  | Add Given/When/Then acceptance criteria      |
+| 800-line mega-spec                             | Split into parent + child specs              |
+| Spec lives in a random location                | Co-locate under `plugins/<name>/docs/specs/` |
+| Starting implementation before spec exists     | Write at least a draft spec first            |
 
 ## References
 

--- a/plugins/sdlc-utils/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utils/.claude-plugin/plugin.json
@@ -17,6 +17,9 @@
     "testing",
     "deployment",
     "maintenance",
-    "software-engineering"
+    "software-engineering",
+    "github-issues",
+    "task-tracking",
+    "project-management"
   ]
 }

--- a/plugins/sdlc-utils/.claude-plugin/plugin.json
+++ b/plugins/sdlc-utils/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-utils",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Software development lifecycle utilities — skills organized by SDLC phase: plan, implement, review, test, deploy, and maintain.",
   "author": {
     "name": "Nathan Heaps",

--- a/plugins/sdlc-utils/README.md
+++ b/plugins/sdlc-utils/README.md
@@ -60,6 +60,15 @@ the spec lifecycle (draft -> live -> archive), and using specs for verification.
 
 **Triggers:** "write a spec", "manage spec lifecycle", "spec template", "update a spec"
 
+### github-issues-task-management
+
+Methodology for organizing work via GitHub Issues and Projects. Covers issue
+lifecycle, PR-to-issue linking, label conventions, project board setup,
+consolidation strategy, and cross-repo references. One concrete implementation
+of the abstract work-tracking rules defined in `agentic-behavior`.
+
+**Triggers:** "set up projects", "create a project board", "organize issues", "milestone planning", "consolidate tickets"
+
 ## Dependencies
 
 - **scm-utils** — the `iterate-until-good` and `review` skills delegate to scm-utils

--- a/plugins/sdlc-utils/skills/github-issues-task-management/SKILL.md
+++ b/plugins/sdlc-utils/skills/github-issues-task-management/SKILL.md
@@ -191,8 +191,8 @@ require `owner/repo#N`.
 
 | Anti-Pattern                                          | Instead                                                |
 | ----------------------------------------------------- | ------------------------------------------------------ |
-| Tracking work only in chat threads                    | Create a GitHub Issue; use chat for discussion          |
-| One issue per tiny sub-task                           | Consolidate into a parent issue with a checklist        |
+| Tracking work only in chat threads                    | Create a GitHub Issue; use chat for discussion         |
+| One issue per tiny sub-task                           | Consolidate into a parent issue with a checklist       |
 | Short-form references across repos (`#N`)             | Use `owner/repo#N` for cross-repo links                |
 | No labels on issues                                   | Add at least type + priority labels                    |
 | Closing issues without explanation                    | Comment with resolution and link to PR/commit          |

--- a/plugins/sdlc-utils/skills/github-issues-task-management/SKILL.md
+++ b/plugins/sdlc-utils/skills/github-issues-task-management/SKILL.md
@@ -2,17 +2,17 @@
 name: github-issues-task-management
 description: >
   This skill should be used when organizing work via GitHub Issues and Projects,
-  creating project boards, managing milestones, or when transitioning from
-  Discord thread-based tracking to GitHub-native tracking. Trigger phrases:
+  creating project boards, managing milestones, or when consolidating fragmented
+  tracking into GitHub-native tracking. Trigger phrases:
   "set up projects", "create a project board", "organize issues", "milestone
   planning", "what issues need attention", "consolidate tickets".
 ---
 
 # GitHub Issues Task Management
 
-GitHub Issues and Projects are the canonical system for tracking work. Discord
-threads are supplementary communication channels, not the source of truth for
-task status or assignments.
+GitHub Issues and Projects are one concrete implementation of project-management
+tracking. This skill covers the methodology for using GitHub as the canonical
+system for tracking work items, milestones, and project status.
 
 ## Core Principles
 
@@ -22,9 +22,9 @@ task status or assignments.
    narrow ones. A single issue for "implement feature X" is better than five
    issues for each sub-task unless the sub-tasks will be worked independently
    by different people or across different PRs.
-3. **Discord supplements, not replaces.** Discord threads are for real-time
-   discussion, status pings, and coordination. The issue is where decisions,
-   acceptance criteria, and resolution are recorded.
+3. **Communication channels supplement, not replace.** Real-time channels (chat,
+   threads) are for discussion, status pings, and coordination. The issue is
+   where decisions, acceptance criteria, and resolution are recorded.
 4. **Link everything.** PRs link to issues. Issues link to project boards.
    Cross-repo references use full `owner/repo#N` format.
 
@@ -54,9 +54,9 @@ Closes #7
 **Semantic convention** (GitHub treats all linking keywords identically, but we
 use them to signal intent to human readers):
 
-- `Fixes` — the PR satisfies/resolves the issue described (bug fix, feature
+- `Fixes` -- the PR satisfies/resolves the issue described (bug fix, feature
   implementation). The issue represents work that is now complete.
-- `Closes` — the PR supersedes or replaces another PR or issue without
+- `Closes` -- the PR supersedes or replaces another PR or issue without
   necessarily implementing it (e.g., a rewrite that obsoletes an older PR, or
   closing a duplicate).
 
@@ -138,8 +138,7 @@ Standard column layout:
 
 ## Consolidation Strategy
 
-When transitioning from fragmented tracking (many small Discord threads, many
-narrow issues) to consolidated GitHub tracking:
+When transitioning from fragmented tracking to consolidated GitHub tracking:
 
 ### Step 1 -- Audit existing issues
 
@@ -159,7 +158,7 @@ Group issues that track the same feature, bug, or initiative. Look for:
 
 - Close duplicates with a comment linking to the canonical issue
 - Merge sub-tasks into a parent issue (add as checklist items in the body)
-- Transfer context from Discord threads into issue comments
+- Transfer context from communication channels into issue comments
 
 ### Step 4 -- Organize into project
 
@@ -186,14 +185,14 @@ require `owner/repo#N`.
 | -------------------------------------------- | ------------------------------------------------------------------------ |
 | `issue-management`                           | Mechanics: how to create, search, update, close issues via CLI           |
 | `github-issues-task-management` (this skill) | Methodology: how to organize work, manage projects, consolidate tracking |
-| `agentic-behavior/rules/work-tracking.md`    | Thread-side discipline: linking, ownership, and milestone coordination   |
+| `agentic-behavior/rules/work-tracking.md`    | Abstract linking and milestone rules (platform-agnostic)                 |
 
 ## Anti-Patterns
 
 | Anti-Pattern                                          | Instead                                                |
 | ----------------------------------------------------- | ------------------------------------------------------ |
-| Tracking work only in Discord threads                 | Create a GitHub Issue; use Discord for discussion      |
-| One issue per tiny sub-task                           | Consolidate into a parent issue with a checklist       |
+| Tracking work only in chat threads                    | Create a GitHub Issue; use chat for discussion          |
+| One issue per tiny sub-task                           | Consolidate into a parent issue with a checklist        |
 | Short-form references across repos (`#N`)             | Use `owner/repo#N` for cross-repo links                |
 | No labels on issues                                   | Add at least type + priority labels                    |
 | Closing issues without explanation                    | Comment with resolution and link to PR/commit          |
@@ -203,5 +202,3 @@ require `owner/repo#N`.
 
 - [GitHub Issues documentation](https://docs.github.com/en/issues)
 - [GitHub Projects documentation](https://docs.github.com/en/issues/planning-and-tracking-with-projects)
-- [`issue-management` skill](../issue-management/SKILL.md) -- CLI mechanics for issue operations
-- [`gh` CLI skill](../../../github/skills/gh/SKILL.md) -- full gh CLI reference


### PR DESCRIPTION
## Summary

Add work-tracking rules and spec-management skills to the agentic-behavior plugin, and move GitHub Issues task management to sdlc-utils as a concrete implementation.

### agentic-behavior plugin changes:
- **`rules/work-tracking.md`** -- Platform-agnostic rules for how tasks, PRs, and milestones relate. Defines abstract linking requirements (work items -> milestones, PRs -> work items), status tracking, and milestone management. No platform-specific references.
- **`skills/spec-management/SKILL.md`** -- Spec lifecycle management with Given/When/Then acceptance criteria format.
- **`README.md`** -- Updated with new skills and rule descriptions.

### sdlc-utils plugin changes:
- **`skills/github-issues-task-management/SKILL.md`** -- Moved from agentic-behavior. One concrete implementation of work tracking using GitHub Issues and Projects. Covers issue lifecycle, PR-to-issue linking, labels, project boards, consolidation strategy, and cross-repo references.
- **`README.md`** -- Added github-issues-task-management skill.

### Design:
Work tracking is split into abstract rules (agentic-behavior) and concrete implementations (sdlc-utils for GitHub, future skills for Linear/file-based). The abstract rules define relationships without naming any platform.

## Test plan

- [ ] Verify agentic-behavior plugin loads without errors (no broken skill references)
- [ ] Verify sdlc-utils plugin loads with the new github-issues-task-management skill
- [ ] Verify no Discord/thread-specific content remains in agentic-behavior
- [ ] Verify marketplace.json keywords are consistent with plugin.json for both plugins