### PR TITLE
Add Claude stream shim for live workflow output

### DIFF
--- a/.github/actions/claude-stream-tail/action.yml
+++ b/.github/actions/claude-stream-tail/action.yml
@@ -30,9 +30,9 @@ inputs:
     required: false
     default: '0.12.13'
   timeout-seconds:
-    description: 'Max seconds to wait for the session to start, and max seconds to follow it. The action exits cleanly (success) on timeout so it does not fail the parallel block.'
+    description: 'Max seconds to wait for the session to start, and max seconds to follow it. The action exits cleanly (success) on timeout so it does not fail the parallel block. Default 600s (10 min) -- bump if reviews routinely run longer.'
     required: false
-    default: '1800'
+    default: '600'
   poll-interval-seconds:
     description: 'How often to poll for a new session JSONL while waiting for it to appear.'
     required: false
@@ -49,6 +49,17 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    # Set the start marker as the VERY FIRST thing so it predates any
+    # competing process writing under ~/.claude/projects. In sidecar mode
+    # alongside claude-code-action via qoomon parallel-steps, both children
+    # start concurrently -- if we marked AFTER our claude-utils install,
+    # the action's SDK could write its first JSONL line before our marker,
+    # and the subsequent `find -newer` would exclude it, hanging the
+    # sidecar for the full timeout.
+    - name: Stamp start marker (must be first)
+      shell: bash
+      run: touch "${RUNNER_TEMP}/claude-stream-tail.start"
+
     - name: Install claude-stream from nsheaps/claude-utils
       shell: bash
       env:
@@ -75,14 +86,17 @@ runs:
         PROJECTS_DIR="${PROJECTS_DIR_OVERRIDE:-$HOME/.claude/projects}"
         mkdir -p "$PROJECTS_DIR"
 
-        # Sidecar mode (default): only pick JSONL files newer than this
-        # start marker, so a pre-existing JSONL on a persistent runner
-        # doesn't get mistaken for the current run's session.
+        # Sidecar mode (default): only pick JSONL files newer than the
+        # start marker (stamped in the FIRST action step, before anything
+        # else, so it predates any competing SDK write).
         # Post-hoc mode (wait-for-new-session=false): drop the marker so
         # the just-completed session (written before this step started)
         # is picked.
         START_MARKER="${RUNNER_TEMP}/claude-stream-tail.start"
-        touch "$START_MARKER"
+        # Defensive: ensure the marker exists. The "Stamp start marker"
+        # step above does this first, but a stale runner re-run might
+        # somehow miss it; touching again is a no-op if present.
+        [ -e "$START_MARKER" ] || touch "$START_MARKER"
 
         if [ "${WAIT_FOR_NEW}" = "true" ]; then
           echo "claude-stream-tail: sidecar mode -- watching $PROJECTS_DIR for a NEW session JSONL (timeout ${TIMEOUT_SECONDS}s)"

--- a/.github/actions/claude-stream-tail/action.yml
+++ b/.github/actions/claude-stream-tail/action.yml
@@ -51,9 +51,17 @@ inputs:
     required: false
     default: ''
   timeout-seconds:
-    description: 'Max seconds to wait for the session to start, and max seconds to follow it. The action exits cleanly (success) on timeout so it does not fail the parallel block. Default 600s (10 min) -- bump if reviews routinely run longer.'
+    description: |
+      Safety ceiling: max seconds to wait for the session to start, and
+      max seconds to follow it. The action exits cleanly (success) on
+      timeout so it never fails the parallel block.
+      With `stop-sentinel` set, the follow normally ends the moment the
+      Stop hook fires -- this timeout is only the fallback. It MUST exceed
+      the longest expected Claude session, otherwise the follow is killed
+      before the session ends and the sentinel never gets a chance to
+      fire. Default 1200s (20 min).
     required: false
-    default: '600'
+    default: '1200'
   poll-interval-seconds:
     description: 'How often to poll for a new session JSONL while waiting for it to appear.'
     required: false

--- a/.github/actions/claude-stream-tail/action.yml
+++ b/.github/actions/claude-stream-tail/action.yml
@@ -1,0 +1,132 @@
+name: 'Claude Stream Tail'
+description: |
+  Sidecar action that pretty-prints a live Claude Code session as a chatroom
+  view. Waits for a fresh session JSONL to appear under ~/.claude/projects/,
+  tails it through claude-stream (from nsheaps/claude-utils), and exits when
+  the SDK writes its terminal result message (or on timeout).
+
+  Designed to run in parallel with anthropics/claude-code-action via
+  qoomon/actions--parallel-steps, since claude-code-action@v1 uses the
+  Claude Agent SDK in-process and no longer spawns the claude CLI (making
+  CLI-wrapper approaches impossible).
+
+  TEMPORARY LOCATION: this action also lives in nsheaps/github-actions but
+  is held here so the workflow can iterate without round-trips through
+  the shared repo. Once stable, this copy should be removed and the
+  workflow should reference nsheaps/github-actions/.github/actions/claude-stream-tail.
+
+author: 'nsheaps'
+
+branding:
+  icon: 'message-circle'
+  color: 'green'
+
+inputs:
+  claude-utils-version:
+    description: 'Tag of nsheaps/claude-utils to install (provides claude-stream). Without leading v.'
+    required: false
+    default: '0.12.13'
+  timeout-seconds:
+    description: 'Max seconds to wait for the session to start, and max seconds to follow it. The action exits cleanly (success) on timeout so it does not fail the parallel block.'
+    required: false
+    default: '1800'
+  poll-interval-seconds:
+    description: 'How often to poll for a new session JSONL while waiting for it to appear.'
+    required: false
+    default: '1'
+  projects-dir:
+    description: 'Override for the Claude Agent SDK projects directory. Defaults to $HOME/.claude/projects.'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install claude-stream from nsheaps/claude-utils
+      shell: bash
+      env:
+        VERSION: ${{ inputs.claude-utils-version }}
+      run: |
+        set -euo pipefail
+        REPO_DIR="${RUNNER_TEMP}/claude-utils"
+        if [ ! -d "$REPO_DIR" ]; then
+          git clone --depth 1 --branch "v${VERSION}" \
+            https://github.com/nsheaps/claude-utils.git "$REPO_DIR"
+        fi
+        echo "$REPO_DIR/bin" >> "$GITHUB_PATH"
+
+    - name: Tail session JSONL through claude-stream
+      shell: bash
+      env:
+        TIMEOUT_SECONDS: ${{ inputs.timeout-seconds }}
+        POLL_INTERVAL_SECONDS: ${{ inputs.poll-interval-seconds }}
+        PROJECTS_DIR_OVERRIDE: ${{ inputs.projects-dir }}
+      run: |
+        set -euo pipefail
+
+        PROJECTS_DIR="${PROJECTS_DIR_OVERRIDE:-$HOME/.claude/projects}"
+        mkdir -p "$PROJECTS_DIR"
+
+        START_MARKER="${RUNNER_TEMP}/claude-stream-tail.start"
+        touch "$START_MARKER"
+
+        echo "claude-stream-tail: watching $PROJECTS_DIR for new session JSONL (timeout ${TIMEOUT_SECONDS}s)"
+
+        START=$(date +%s)
+        SESSION_FILE=""
+
+        # Wait for a NEW session JSONL to appear (newer than our start marker).
+        while true; do
+          NOW=$(date +%s)
+          ELAPSED=$((NOW - START))
+          if [ "$ELAPSED" -ge "$TIMEOUT_SECONDS" ]; then
+            echo "claude-stream-tail: timed out after ${TIMEOUT_SECONDS}s with no session file" >&2
+            exit 0
+          fi
+          # Newest *.jsonl created after our start marker, anywhere under projects dir.
+          SESSION_FILE="$(find "$PROJECTS_DIR" -type f -name '*.jsonl' -newer "$START_MARKER" -printf '%T@ %p\n' 2>/dev/null \
+            | sort -nr | head -1 | awk '{print $2}')"
+          if [ -n "$SESSION_FILE" ] && [ -f "$SESSION_FILE" ]; then
+            break
+          fi
+          sleep "$POLL_INTERVAL_SECONDS"
+        done
+
+        echo "claude-stream-tail: tailing $SESSION_FILE"
+
+        # Remaining time budget for the follow phase.
+        NOW=$(date +%s)
+        REMAINING=$((TIMEOUT_SECONDS - (NOW - START)))
+        [ "$REMAINING" -lt 30 ] && REMAINING=30
+
+        # Pipeline:
+        #   tail -F (line-buffered)  -> awk (exit on terminal "result" line)  -> claude-stream
+        # awk closing its stdin makes claude-stream finish cleanly; tail dies via SIGPIPE.
+        # `timeout` caps the whole pipeline so a stuck session can't hold the parallel block.
+        set +e
+        timeout --foreground --signal=TERM "${REMAINING}" bash -c '
+          set -o pipefail
+          stdbuf -oL tail -n +1 -F "$1" 2>/dev/null \
+            | stdbuf -oL awk "{
+                print;
+                fflush();
+                if (\$0 ~ /\"type\":[[:space:]]*\"result\"/) { exit }
+              }" \
+            | claude-stream
+        ' _ "$SESSION_FILE"
+        STATUS=$?
+        set -e
+
+        # 124 = GNU timeout fired. We treat that as success (do not fail the parallel block):
+        # the main claude-code-action step is the source of truth for success/failure.
+        if [ "$STATUS" -eq 124 ]; then
+          echo "claude-stream-tail: follow phase hit ${REMAINING}s timeout" >&2
+          exit 0
+        fi
+        # SIGPIPE from tail / claude-stream is normal at end-of-stream; don't fail on it.
+        if [ "$STATUS" -eq 141 ] || [ "$STATUS" -eq 0 ]; then
+          echo "claude-stream-tail: done"
+          exit 0
+        fi
+        echo "claude-stream-tail: pipeline exited with status $STATUS (non-fatal)" >&2
+        exit 0

--- a/.github/actions/claude-stream-tail/action.yml
+++ b/.github/actions/claude-stream-tail/action.yml
@@ -30,9 +30,9 @@ inputs:
     required: false
     default: '0.12.13'
   timeout-seconds:
-    description: 'Max seconds to wait for the session to start, and max seconds to follow it. The action exits cleanly (success) on timeout so it does not fail the parallel block. Default 600s (10 min) -- bump if reviews routinely run longer.'
+    description: 'Max seconds to wait for the session to start, and max seconds to follow it. The action exits cleanly (success) on timeout so it does not fail the parallel block. Default 300s (5 min) for fast iteration -- bump for longer reviews.'
     required: false
-    default: '600'
+    default: '300'
   poll-interval-seconds:
     description: 'How often to poll for a new session JSONL while waiting for it to appear.'
     required: false
@@ -109,17 +109,38 @@ runs:
         START=$(date +%s)
         SESSION_FILE=""
 
+        # DIAGNOSTIC: dump initial state.
+        echo "::group::claude-stream-tail diagnostics"
+        echo "HOME=$HOME"
+        echo "RUNNER_TEMP=$RUNNER_TEMP"
+        echo "PROJECTS_DIR=$PROJECTS_DIR"
+        echo "WAIT_FOR_NEW=$WAIT_FOR_NEW"
+        echo "TIMEOUT_SECONDS=$TIMEOUT_SECONDS"
+        echo "START_MARKER mtime: $(stat -c '%y' "$START_MARKER" 2>/dev/null || echo missing)"
+        echo "projects dir initial contents:"
+        find "$PROJECTS_DIR" -maxdepth 3 -type f 2>/dev/null | head -20 || echo "  (empty or missing)"
+        echo "command -v claude-stream: $(command -v claude-stream || echo NOT_FOUND)"
+        echo "::endgroup::"
+
         while true; do
           NOW=$(date +%s)
           ELAPSED=$((NOW - START))
           if [ "$ELAPSED" -ge "$TIMEOUT_SECONDS" ]; then
             echo "claude-stream-tail: timed out after ${TIMEOUT_SECONDS}s with no session file" >&2
+            echo "::group::final state at timeout" >&2
+            find "$PROJECTS_DIR" -maxdepth 3 -type f -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -20 >&2 || true
+            echo "::endgroup::" >&2
             exit 0
           fi
           SESSION_FILE="$(find "$PROJECTS_DIR" -type f -name '*.jsonl' "${FIND_FILTER[@]}" -printf '%T@ %p\n' 2>/dev/null \
             | sort -nr | head -1 | awk '{print $2}')"
           if [ -n "$SESSION_FILE" ] && [ -f "$SESSION_FILE" ]; then
             break
+          fi
+          # Every 10s while waiting, log what we DO see (might be in wrong dir).
+          if [ "$((ELAPSED % 10))" -eq 0 ] && [ "$ELAPSED" -gt 0 ]; then
+            echo "claude-stream-tail: still waiting (${ELAPSED}s) -- jsonl files anywhere on host:"
+            find / -name '*.jsonl' -path '*/claude/*' -printf '  %T@ %p\n' 2>/dev/null | sort -nr | head -5 || true
           fi
           sleep "$POLL_INTERVAL_SECONDS"
         done
@@ -134,9 +155,10 @@ runs:
         # Pipeline:
         #   tail -F (line-buffered)  -> awk (exit on terminal "result" line)  -> claude-stream
         # awk closing its stdin makes claude-stream finish cleanly; tail dies via SIGPIPE.
-        # `timeout` caps the whole pipeline so a stuck session can't hold the parallel block.
+        # `timeout` with -k caps the whole pipeline. Dropped --foreground (only
+        # meaningful with a TTY; we run in CI without one).
         set +e
-        timeout --foreground --signal=TERM "${REMAINING}" bash -c '
+        timeout -k 30 --signal=TERM "${REMAINING}" bash -c '
           set -o pipefail
           stdbuf -oL tail -n +1 -F "$1" 2>/dev/null \
             | stdbuf -oL awk "{

--- a/.github/actions/claude-stream-tail/action.yml
+++ b/.github/actions/claude-stream-tail/action.yml
@@ -1,19 +1,24 @@
 name: 'Claude Stream Tail'
 description: |
-  Sidecar action that pretty-prints a live Claude Code session as a chatroom
-  view. Waits for a fresh session JSONL to appear under ~/.claude/projects/,
-  tails it through claude-stream (from nsheaps/claude-utils), and exits when
-  the SDK writes its terminal result message (or on timeout).
+  Renders a Claude Code session as a colored chatroom view in the workflow
+  log. Picks the most recent *.jsonl file under ~/.claude/projects/ (the
+  Claude Agent SDK's session store) and tails it through claude-stream
+  (from nsheaps/claude-utils), exiting when the SDK writes its terminal
+  result message or on timeout.
 
-  Designed to run in parallel with anthropics/claude-code-action via
-  qoomon/actions--parallel-steps, since claude-code-action@v1 uses the
-  Claude Agent SDK in-process and no longer spawns the claude CLI (making
-  CLI-wrapper approaches impossible).
+  This copy is post-hoc only -- it intentionally drops the upstream's
+  start-marker freshness filter so it can pick up a session JSONL that
+  was written before this step started (e.g. by a preceding
+  anthropics/claude-code-action step). Safe on fresh CI runners where no
+  stale JSONL can exist; would pick stale data on persistent / self-hosted
+  runners with a previous Claude session in $HOME/.claude/projects/.
 
-  TEMPORARY LOCATION: this action also lives in nsheaps/github-actions but
-  is held here so the workflow can iterate without round-trips through
-  the shared repo. Once stable, this copy should be removed and the
-  workflow should reference nsheaps/github-actions/.github/actions/claude-stream-tail.
+  TEMPORARY LOCATION: this action will move to
+  nsheaps/github-actions/.github/actions/claude-stream-tail once a
+  unified version supports both post-hoc (this) and sidecar (with
+  freshness filter) modes via an input. Until then, this in-repo copy
+  exists so the workflow can be iterated on without cross-repo round-trips.
+  Tracking: nsheaps/github-actions branch claude/stream-action-output-UtYyT.
 
 author: 'nsheaps'
 

--- a/.github/actions/claude-stream-tail/action.yml
+++ b/.github/actions/claude-stream-tail/action.yml
@@ -1,23 +1,21 @@
 name: 'Claude Stream Tail'
 description: |
   Renders a Claude Code session as a colored chatroom view in the workflow
-  log. Picks the most recent *.jsonl file under ~/.claude/projects/ (the
-  Claude Agent SDK's session store) and tails it through claude-stream
-  (from nsheaps/claude-utils), exiting when the SDK writes its terminal
-  result message or on timeout.
+  log. Picks a *.jsonl file under ~/.claude/projects/ (the Claude Agent
+  SDK's session store) and tails it through claude-stream (from
+  nsheaps/claude-utils), exiting when the SDK writes its terminal result
+  message or on timeout.
 
-  This copy is post-hoc only -- it intentionally drops the upstream's
-  start-marker freshness filter so it can pick up a session JSONL that
-  was written before this step started (e.g. by a preceding
-  anthropics/claude-code-action step). Safe on fresh CI runners where no
-  stale JSONL can exist; would pick stale data on persistent / self-hosted
-  runners with a previous Claude session in $HOME/.claude/projects/.
+  Two modes via `wait-for-new-session`:
+    - true (default, sidecar): wait for a JSONL that appears AFTER this
+      action starts. Safe alongside anthropics/claude-code-action via
+      qoomon/actions--parallel-steps; ignores any pre-existing JSONL on
+      persistent runners.
+    - false (post-hoc): pick the most recent JSONL regardless of age.
+      Use after the action ran so the just-completed session is rendered.
 
   TEMPORARY LOCATION: this action will move to
-  nsheaps/github-actions/.github/actions/claude-stream-tail once a
-  unified version supports both post-hoc (this) and sidecar (with
-  freshness filter) modes via an input. Until then, this in-repo copy
-  exists so the workflow can be iterated on without cross-repo round-trips.
+  nsheaps/github-actions/.github/actions/claude-stream-tail once stable.
   Tracking: nsheaps/github-actions branch claude/stream-action-output-UtYyT.
 
 author: 'nsheaps'
@@ -43,6 +41,10 @@ inputs:
     description: 'Override for the Claude Agent SDK projects directory. Defaults to $HOME/.claude/projects.'
     required: false
     default: ''
+  wait-for-new-session:
+    description: 'true = sidecar mode (only pick JSONL files created after this action starts); false = post-hoc mode (pick the most recent JSONL regardless of age).'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -66,22 +68,33 @@ runs:
         TIMEOUT_SECONDS: ${{ inputs.timeout-seconds }}
         POLL_INTERVAL_SECONDS: ${{ inputs.poll-interval-seconds }}
         PROJECTS_DIR_OVERRIDE: ${{ inputs.projects-dir }}
+        WAIT_FOR_NEW: ${{ inputs.wait-for-new-session }}
       run: |
         set -euo pipefail
 
         PROJECTS_DIR="${PROJECTS_DIR_OVERRIDE:-$HOME/.claude/projects}"
         mkdir -p "$PROJECTS_DIR"
 
-        echo "claude-stream-tail: watching $PROJECTS_DIR for the newest session JSONL (timeout ${TIMEOUT_SECONDS}s)"
+        # Sidecar mode (default): only pick JSONL files newer than this
+        # start marker, so a pre-existing JSONL on a persistent runner
+        # doesn't get mistaken for the current run's session.
+        # Post-hoc mode (wait-for-new-session=false): drop the marker so
+        # the just-completed session (written before this step started)
+        # is picked.
+        START_MARKER="${RUNNER_TEMP}/claude-stream-tail.start"
+        touch "$START_MARKER"
+
+        if [ "${WAIT_FOR_NEW}" = "true" ]; then
+          echo "claude-stream-tail: sidecar mode -- watching $PROJECTS_DIR for a NEW session JSONL (timeout ${TIMEOUT_SECONDS}s)"
+          FIND_FILTER=(-newer "$START_MARKER")
+        else
+          echo "claude-stream-tail: post-hoc mode -- watching $PROJECTS_DIR for the most recent session JSONL (timeout ${TIMEOUT_SECONDS}s)"
+          FIND_FILTER=()
+        fi
 
         START=$(date +%s)
         SESSION_FILE=""
 
-        # Wait for the newest session JSONL to appear. In live mode (sidecar
-        # alongside claude-code-action) this loops until the SDK creates one;
-        # in post-hoc mode (run after the action) it picks the just-finished
-        # session immediately. CI runners are fresh per job, so no stale-file
-        # filter is needed.
         while true; do
           NOW=$(date +%s)
           ELAPSED=$((NOW - START))
@@ -89,7 +102,7 @@ runs:
             echo "claude-stream-tail: timed out after ${TIMEOUT_SECONDS}s with no session file" >&2
             exit 0
           fi
-          SESSION_FILE="$(find "$PROJECTS_DIR" -type f -name '*.jsonl' -printf '%T@ %p\n' 2>/dev/null \
+          SESSION_FILE="$(find "$PROJECTS_DIR" -type f -name '*.jsonl' "${FIND_FILTER[@]}" -printf '%T@ %p\n' 2>/dev/null \
             | sort -nr | head -1 | awk '{print $2}')"
           if [ -n "$SESSION_FILE" ] && [ -f "$SESSION_FILE" ]; then
             break

--- a/.github/actions/claude-stream-tail/action.yml
+++ b/.github/actions/claude-stream-tail/action.yml
@@ -30,9 +30,9 @@ inputs:
     required: false
     default: '0.12.13'
   timeout-seconds:
-    description: 'Max seconds to wait for the session to start, and max seconds to follow it. The action exits cleanly (success) on timeout so it does not fail the parallel block. Default 300s (5 min) for fast iteration -- bump for longer reviews.'
+    description: 'Max seconds to wait for the session to start, and max seconds to follow it. The action exits cleanly (success) on timeout so it does not fail the parallel block. Default 600s (10 min) -- bump if reviews routinely run longer.'
     required: false
-    default: '300'
+    default: '600'
   poll-interval-seconds:
     description: 'How often to poll for a new session JSONL while waiting for it to appear.'
     required: false
@@ -137,10 +137,12 @@ runs:
           if [ -n "$SESSION_FILE" ] && [ -f "$SESSION_FILE" ]; then
             break
           fi
-          # Every 10s while waiting, log what we DO see (might be in wrong dir).
+          # Every 10s while waiting, log what we DO see in the plausible
+          # JSONL write paths (might be in a different dir than $PROJECTS_DIR).
+          # Search roots constrained per CLAUDE.md (no full-/ walks).
           if [ "$((ELAPSED % 10))" -eq 0 ] && [ "$ELAPSED" -gt 0 ]; then
-            echo "claude-stream-tail: still waiting (${ELAPSED}s) -- jsonl files anywhere on host:"
-            find / -name '*.jsonl' -path '*/claude/*' -printf '  %T@ %p\n' 2>/dev/null | sort -nr | head -5 || true
+            echo "claude-stream-tail: still waiting (${ELAPSED}s) -- jsonl files in plausible paths:"
+            find "$HOME" /root /tmp /var/tmp -name '*.jsonl' -path '*/claude/*' -printf '  %T@ %p\n' 2>/dev/null | sort -nr | head -5 || true
           fi
           sleep "$POLL_INTERVAL_SECONDS"
         done

--- a/.github/actions/claude-stream-tail/action.yml
+++ b/.github/actions/claude-stream-tail/action.yml
@@ -3,8 +3,14 @@ description: |
   Renders a Claude Code session as a colored chatroom view in the workflow
   log. Picks a *.jsonl file under ~/.claude/projects/ (the Claude Agent
   SDK's session store) and tails it through claude-stream (from
-  nsheaps/claude-utils), exiting when the SDK writes its terminal result
-  message or on timeout.
+  nsheaps/claude-utils).
+
+  The follow ends when claude-stream sees the stop sentinel (pass
+  `stop-sentinel`; pair with a Claude Code Stop hook that echoes the same
+  value into the session) or when `timeout-seconds` elapses. Note: the
+  SDK's `{"type":"result"}` message is NOT written to the session JSONL
+  -- it is an SDK stream message -- so it cannot be used as a terminal
+  marker by a JSONL tailer.
 
   Two modes via `wait-for-new-session`:
     - true (default, sidecar): wait for a JSONL that appears AFTER this
@@ -25,10 +31,25 @@ branding:
   color: 'green'
 
 inputs:
-  claude-utils-version:
-    description: 'Tag of nsheaps/claude-utils to install (provides claude-stream). Without leading v.'
+  claude-utils-ref:
+    description: |
+      Git ref of nsheaps/claude-utils to install (provides claude-stream).
+      Any ref works: a tag (e.g. v0.12.14) or a branch. Currently a branch,
+      because the --exit-on-session-stop flag this action depends on is not
+      yet on a release tag.
+      TODO: pin to a release tag once claude-utils ships the flag.
     required: false
-    default: '0.12.13'
+    default: 'claude/stream-action-output-UtYyT'
+  stop-sentinel:
+    description: |
+      Sentinel string passed to `claude-stream --exit-on-session-stop`.
+      claude-stream exits cleanly once it sees this string in the session
+      JSONL. Pair with a Claude Code Stop hook that echoes the same value.
+      Leave empty to disable stop detection (the timeout still bounds the
+      follow). Callers should pass a run-unique value so reviewed content
+      cannot false-trigger an early exit.
+    required: false
+    default: ''
   timeout-seconds:
     description: 'Max seconds to wait for the session to start, and max seconds to follow it. The action exits cleanly (success) on timeout so it does not fail the parallel block. Default 600s (10 min) -- bump if reviews routinely run longer.'
     required: false
@@ -63,12 +84,12 @@ runs:
     - name: Install claude-stream from nsheaps/claude-utils
       shell: bash
       env:
-        VERSION: ${{ inputs.claude-utils-version }}
+        REF: ${{ inputs.claude-utils-ref }}
       run: |
         set -euo pipefail
         REPO_DIR="${RUNNER_TEMP}/claude-utils"
         if [ ! -d "$REPO_DIR" ]; then
-          git clone --depth 1 --branch "v${VERSION}" \
+          git clone --depth 1 --branch "$REF" \
             https://github.com/nsheaps/claude-utils.git "$REPO_DIR"
         fi
         echo "$REPO_DIR/bin" >> "$GITHUB_PATH"
@@ -80,6 +101,7 @@ runs:
         POLL_INTERVAL_SECONDS: ${{ inputs.poll-interval-seconds }}
         PROJECTS_DIR_OVERRIDE: ${{ inputs.projects-dir }}
         WAIT_FOR_NEW: ${{ inputs.wait-for-new-session }}
+        STOP_SENTINEL: ${{ inputs.stop-sentinel }}
       run: |
         set -euo pipefail
 
@@ -154,35 +176,40 @@ runs:
         REMAINING=$((TIMEOUT_SECONDS - (NOW - START)))
         [ "$REMAINING" -lt 30 ] && REMAINING=30
 
-        # Pipeline:
-        #   tail -F (line-buffered)  -> awk (exit on terminal "result" line)  -> claude-stream
-        # awk closing its stdin makes claude-stream finish cleanly; tail dies via SIGPIPE.
-        # `timeout` with -k caps the whole pipeline. Dropped --foreground (only
-        # meaningful with a TTY; we run in CI without one).
+        # claude-stream --file does its own `tail -F`. --exit-on-session-stop
+        # makes it exit cleanly once the stop sentinel appears in the JSONL
+        # (a Stop hook echoes the sentinel; the hook's stdout is recorded
+        # into the session JSONL as a hook_success attachment). Without a
+        # sentinel there is no terminal record to key off and the follow
+        # would run until the timeout below.
+        #
+        # `timeout` with -k still caps the whole thing: if the Stop hook
+        # never fires (misconfig) the follow ends at REMAINING seconds
+        # rather than hanging. The main claude-code-action step is the
+        # source of truth for the job's success/failure.
+        cs_args=(--file "$SESSION_FILE")
+        if [ -n "${STOP_SENTINEL}" ]; then
+          cs_args+=(--exit-on-session-stop --stop-sentinel "${STOP_SENTINEL}")
+          echo "claude-stream-tail: will exit on session-stop sentinel"
+        else
+          echo "claude-stream-tail: no stop sentinel set -- follow bounded only by ${REMAINING}s timeout" >&2
+        fi
+
         set +e
-        timeout -k 30 --signal=TERM "${REMAINING}" bash -c '
-          set -o pipefail
-          stdbuf -oL tail -n +1 -F "$1" 2>/dev/null \
-            | stdbuf -oL awk "{
-                print;
-                fflush();
-                if (\$0 ~ /\"type\":[[:space:]]*\"result\"/) { exit }
-              }" \
-            | claude-stream
-        ' _ "$SESSION_FILE"
+        timeout -k 30 --signal=TERM "${REMAINING}" claude-stream "${cs_args[@]}"
         STATUS=$?
         set -e
 
-        # 124 = GNU timeout fired. We treat that as success (do not fail the parallel block):
-        # the main claude-code-action step is the source of truth for success/failure.
+        # 124 = GNU timeout fired. Treat as success (do not fail the parallel
+        # block) -- claude-code-action governs the job's real outcome.
         if [ "$STATUS" -eq 124 ]; then
           echo "claude-stream-tail: follow phase hit ${REMAINING}s timeout" >&2
           exit 0
         fi
-        # SIGPIPE from tail / claude-stream is normal at end-of-stream; don't fail on it.
+        # SIGPIPE (141) is normal at end-of-stream; 0 is a clean session-stop.
         if [ "$STATUS" -eq 141 ] || [ "$STATUS" -eq 0 ]; then
           echo "claude-stream-tail: done"
           exit 0
         fi
-        echo "claude-stream-tail: pipeline exited with status $STATUS (non-fatal)" >&2
+        echo "claude-stream-tail: claude-stream exited with status $STATUS (non-fatal)" >&2
         exit 0

--- a/.github/actions/claude-stream-tail/action.yml
+++ b/.github/actions/claude-stream-tail/action.yml
@@ -67,15 +67,16 @@ runs:
         PROJECTS_DIR="${PROJECTS_DIR_OVERRIDE:-$HOME/.claude/projects}"
         mkdir -p "$PROJECTS_DIR"
 
-        START_MARKER="${RUNNER_TEMP}/claude-stream-tail.start"
-        touch "$START_MARKER"
-
-        echo "claude-stream-tail: watching $PROJECTS_DIR for new session JSONL (timeout ${TIMEOUT_SECONDS}s)"
+        echo "claude-stream-tail: watching $PROJECTS_DIR for the newest session JSONL (timeout ${TIMEOUT_SECONDS}s)"
 
         START=$(date +%s)
         SESSION_FILE=""
 
-        # Wait for a NEW session JSONL to appear (newer than our start marker).
+        # Wait for the newest session JSONL to appear. In live mode (sidecar
+        # alongside claude-code-action) this loops until the SDK creates one;
+        # in post-hoc mode (run after the action) it picks the just-finished
+        # session immediately. CI runners are fresh per job, so no stale-file
+        # filter is needed.
         while true; do
           NOW=$(date +%s)
           ELAPSED=$((NOW - START))
@@ -83,8 +84,7 @@ runs:
             echo "claude-stream-tail: timed out after ${TIMEOUT_SECONDS}s with no session file" >&2
             exit 0
           fi
-          # Newest *.jsonl created after our start marker, anywhere under projects dir.
-          SESSION_FILE="$(find "$PROJECTS_DIR" -type f -name '*.jsonl' -newer "$START_MARKER" -printf '%T@ %p\n' 2>/dev/null \
+          SESSION_FILE="$(find "$PROJECTS_DIR" -type f -name '*.jsonl' -printf '%T@ %p\n' 2>/dev/null \
             | sort -nr | head -1 | awk '{print $2}')"
           if [ -n "$SESSION_FILE" ] && [ -f "$SESSION_FILE" ]; then
             break

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -83,145 +83,168 @@ jobs:
         with:
           template-file: .github/prompts/claude-code-review.md
 
-      # Runs claude-code-action and a live chatroom-view sidecar in parallel
-      # within the same job. The sidecar (claude-stream-tail) waits for the
-      # SDK to create its session JSONL under ~/.claude/projects/ and tails
-      # it through claude-stream (from nsheaps/claude-utils) so the workflow
-      # log shows a colored chatroom view as Claude works. The parallel
-      # action streams both substeps' output live into a "Concurrent logs"
-      # group (each line prefixed [N]) and also replays each substep's
-      # output in its own group at end.
+      # claude-code-action runs sequentially. show_full_output: true keeps
+      # the original behavior: raw stream-json dumps to the workflow log
+      # live as Claude works. The post-hoc claude-stream-tail step below
+      # then renders the same session as a colored chatroom view -- both
+      # surfaces are visible in the run log.
       #
-      # claude-code-action@v1 calls the Claude Agent SDK in-process and no
-      # longer spawns the claude CLI, so a CLI-wrapper approach (the prior
-      # claude-stream-shim) is a no-op against v1. Tailing the SDK session
-      # file is the SDK-friendly equivalent.
-      #
-      # show_full_output: false suppresses the raw JSON dump in the
-      # claude-code-action substep's output; the live chatroom comes from
-      # the sidecar's stdout/stderr instead.
-      # TODO: re-pin nsheaps/github-actions references to post-merge SHAs
-      # on main once claude/stream-action-output-UtYyT merges. Branch ref
-      # used during development so shim/tail iterations flow through.
-      - name: Run claude review + live chatroom (parallel)
+      # The earlier attempt at qoomon/actions--parallel-steps + a sidecar
+      # tail action did not work: parallel-steps takes its `steps:` input
+      # as a string and re-parses it as YAML, but GitHub interpolates any
+      # multi-line ${{ }} expressions inside that string verbatim, so
+      # multi-line values (the 458-line prompt template, the multi-line
+      # settings JSON) wrecked the embedded YAML structure. Sequential is
+      # the simplest path that exercises the streaming action end-to-end.
+      - name: Run Claude Code Review
         id: claude-review
-        uses: qoomon/actions--parallel-steps@v1
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: '${{ steps.auth.outputs.token }}'
+          GITHUB_TOKEN: '${{ steps.auth.outputs.token }}'
+          # These are in addition to any parsed settings.json files
+          # Prefer this over claude_args, almost everything can be specified via settings json or env vars
+          # While Bash is allowed, the list here is passed directly to the agent, so explicitly defining them
+          # causes the agent to see those Bash commands as more relevant and will use them more often.
+          # Ref: https://code.claude.com/docs/en/settings
+          INPUT_SETTINGS_JSON: |
+            {
+              "permissions": {
+                "additionalDirectories": ["/tmp/"],
+                "allow":[
+                  "Task",
+                  "Glob",
+                  "Grep",
+                  "LS",
+                  "ExitPlanMode",
+                  "Read",
+                  "Edit",
+                  "Write",
+                  "Replace",
+                  "MultiEdit",
+                  "NotebookRead",
+                  "NotebookEdit",
+                  "TodoWrite",
+                  "WebSearch",
+                  "WebFetch",
+                  "Bash",
+                  "BashOutput",
+                  "KillBash",
+                  "ListMcpResourcesTool",
+                  "ReadMcpResourceTool",
+                  "SlashCommand",
+                  "Skill",
+
+                  "mcp__github__github_support_docs_search",
+                  "mcp__github__get_pull_request",
+                  "mcp__github__get_pull_request_diff",
+                  "mcp__github__get_pull_request_files",
+                  "mcp__github__get_pull_request_review_comments",
+                  "mcp__github__get_pull_request_reviews",
+                  "mcp__github__get_pull_request_status",
+                  "mcp__github__create_pending_pull_request_review",
+                  "mcp__github__add_comment_to_pending_review",
+                  "mcp__github__submit_pending_pull_request_review",
+
+                  "Bash(git log:*)",
+                  "Bash(git diff:*)",
+                  "Bash(git status:*)",
+                  "Bash(git rev-parse:*)",
+                  "Bash(git fetch:*)",
+                  "Bash(git show:*)",
+                  "Bash(git merge:*)",
+                  "Bash(git remote get-url:*)",
+                  "Bash(git rm:*)",
+                  "Bash(gh issue view:*)",
+                  "Bash(gh search:*)",
+                  "Bash(gh issue list:*)",
+                  "Bash(gh pr comment:*)",
+                  "Bash(gh pr diff:*)",
+                  "Bash(gh pr view:*)",
+                  "Bash(gh pr-review:*)",
+                  "Bash(gh pr-review review view:*)",
+                  "Bash(gh pr list:*)",
+                  "Bash(gh run list:*)",
+                  "Bash(gh run view:*)",
+                  "Bash(gh extension list:*)"
+                ],
+                "_denyComment": "It will wait for it's own check run to complete, not to mention it should review the code.",
+                "deny": [
+                  "mcp__github_ci__get_ci_status",
+                  "mcp__github_ci__get_workflow_run_details",
+                  "mcp__github_ci__download_job_log",
+                  "Bash(gh pr checks:*)",
+                  "Bash(git push:*)"
+                ]
+              },
+              "model": "opus",
+              "env": {
+                "GH_TOKEN": "${{ steps.auth.outputs.token }}",
+                "GITHUB_TOKEN": "${{ steps.auth.outputs.token }}",
+                "_GH_PAGER_COMMENT": "disable gh from being able to treat the terminal as interactive",
+                "GH_PAGER": "cat",
+                "GH_PROMPT_DISABLED": "true",
+                "_GH_BROWSER_COMMENT": "what app to open URLs with, since claude is not interactive, we use curl to pipe it to stdout",
+                "GH_BROWSER": "curl",
+                "CLAUDE_CODE_REMOTE": "true"
+              }
+            }
         with:
-          steps: |
-            - id: review
-              uses: anthropics/claude-code-action@v1
-              env:
-                GH_TOKEN: '${{ steps.auth.outputs.token }}'
-                GITHUB_TOKEN: '${{ steps.auth.outputs.token }}'
-              with:
-                anthropic_api_key: ${{ secrets.REVIEW_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY || '' }}
-                claude_code_oauth_token: ${{ (secrets.REVIEW_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY) && '' || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-                show_full_output: false
-                # bug: https://github.com/anthropics/claude-code-action/issues/759
-                # won't find the past comments since it's looking for github-actions[bot], not the auth it uses to post the comment.
-                bot_id: ${{ steps.auth.outputs.user-id }}
-                bot_name: ${{ steps.auth.outputs.user-name }}
-                allowed_bots: 'github-actions[bot],renovate[bot],claude[bot],automation-nsheaps[bot],jack-nsheaps[bot],henry-nsheaps[bot],alex-nsheaps[bot]'
-                github_token: ${{ steps.auth.outputs.token }}
-                # Inlined here as a YAML literal scalar (NOT via env. interpolation)
-                # because qoomon/actions--parallel-steps re-parses the `steps: |`
-                # value as YAML; multi-line ${{ env.X }} substitution into the
-                # outer literal scalar would wreck this embedded YAML's
-                # indentation. ${{ steps.auth.outputs.token }} expressions inside
-                # are still evaluated by GitHub at workflow-parse time.
-                settings: |
-                  {
-                    "permissions": {
-                      "additionalDirectories": ["/tmp/"],
-                      "allow": [
-                        "Task", "Glob", "Grep", "LS", "ExitPlanMode",
-                        "Read", "Edit", "Write", "Replace", "MultiEdit",
-                        "NotebookRead", "NotebookEdit", "TodoWrite",
-                        "WebSearch", "WebFetch",
-                        "Bash", "BashOutput", "KillBash",
-                        "ListMcpResourcesTool", "ReadMcpResourceTool",
-                        "SlashCommand", "Skill",
+          anthropic_api_key: ${{ secrets.REVIEW_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY || '' }}
+          claude_code_oauth_token: ${{ (secrets.REVIEW_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY) && '' || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # WARNING: PRINTS FULL JSON OUTPUT WHICH MAY INCLUDE SECRETS.
+          # ONLY USE IN PRIVATE ENVIRONMENTS. Kept ON so the workflow log
+          # has a live signal during the run; the post-hoc claude-stream-tail
+          # step below also renders a chatroom view of the same session.
+          show_full_output: true
+          # bug: https://github.com/anthropics/claude-code-action/issues/759
+          # won't find the past comments since it's looking for github-actions[bot], not the auth it uses to post the comment.
+          bot_id: ${{ steps.auth.outputs.user-id }}
+          bot_name: ${{ steps.auth.outputs.user-name }}
+          allowed_bots: 'github-actions[bot],renovate[bot],claude[bot],automation-nsheaps[bot],jack-nsheaps[bot],henry-nsheaps[bot],alex-nsheaps[bot]'
+          github_token: ${{ steps.auth.outputs.token }}
+          settings: ${{ env.INPUT_SETTINGS_JSON }}
+          additional_permissions: |
+            actions: read
+          # Prompt is loaded from external template file via interpolate-prompt action
+          prompt: ${{ steps.prompt.outputs.prompt }}
+          # Prefer using settings.json, but some are needed to be set here for the action
+          # to automatically enable the MCP servers. Placing anything with `mcp__github__` prefix will enable the github mcp server.
+          # See https://github.com/anthropics/claude-code-action/issues/723#issuecomment-3716307305
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+          # Note: We intentionally do NOT include 'github_comment' (used for Claude's persistent "working on it" comment)
+          # or 'github_inline_comment' (used for inline comments outside of reviews) in the allowed tools / claude_args,
+          # to prevent Claude from posting persistent status comments or inline comments outside of proper reviews.
+          claude_args: >-
+            --allowedTools
+            mcp__github__github_support_docs_search,
+            mcp__github__get_pull_request,
+            mcp__github__get_pull_request_diff,
+            mcp__github__get_pull_request_files,
+            mcp__github__get_pull_request_review_comments,
+            mcp__github__get_pull_request_reviews,
+            mcp__github__get_pull_request_status,
+            mcp__github__create_pending_pull_request_review,
+            mcp__github__add_comment_to_pending_review,
+            mcp__github__submit_pending_pull_request_review
 
-                        "mcp__github__github_support_docs_search",
-                        "mcp__github__get_pull_request",
-                        "mcp__github__get_pull_request_diff",
-                        "mcp__github__get_pull_request_files",
-                        "mcp__github__get_pull_request_review_comments",
-                        "mcp__github__get_pull_request_reviews",
-                        "mcp__github__get_pull_request_status",
-                        "mcp__github__create_pending_pull_request_review",
-                        "mcp__github__add_comment_to_pending_review",
-                        "mcp__github__submit_pending_pull_request_review",
-
-                        "Bash(git log:*)",
-                        "Bash(git diff:*)",
-                        "Bash(git status:*)",
-                        "Bash(git rev-parse:*)",
-                        "Bash(git fetch:*)",
-                        "Bash(git show:*)",
-                        "Bash(git merge:*)",
-                        "Bash(git remote get-url:*)",
-                        "Bash(git rm:*)",
-                        "Bash(gh issue view:*)",
-                        "Bash(gh search:*)",
-                        "Bash(gh issue list:*)",
-                        "Bash(gh pr comment:*)",
-                        "Bash(gh pr diff:*)",
-                        "Bash(gh pr view:*)",
-                        "Bash(gh pr-review:*)",
-                        "Bash(gh pr-review review view:*)",
-                        "Bash(gh pr list:*)",
-                        "Bash(gh run list:*)",
-                        "Bash(gh run view:*)",
-                        "Bash(gh extension list:*)"
-                      ],
-                      "_denyComment": "It will wait for it's own check run to complete, not to mention it should review the code.",
-                      "deny": [
-                        "mcp__github_ci__get_ci_status",
-                        "mcp__github_ci__get_workflow_run_details",
-                        "mcp__github_ci__download_job_log",
-                        "Bash(gh pr checks:*)",
-                        "Bash(git push:*)"
-                      ]
-                    },
-                    "model": "opus",
-                    "env": {
-                      "GH_TOKEN": "${{ steps.auth.outputs.token }}",
-                      "GITHUB_TOKEN": "${{ steps.auth.outputs.token }}",
-                      "GH_PAGER": "cat",
-                      "GH_PROMPT_DISABLED": "true",
-                      "GH_BROWSER": "curl",
-                      "CLAUDE_CODE_REMOTE": "true"
-                    }
-                  }
-                additional_permissions: |
-                  actions: read
-                # Prompt is loaded from external template file via interpolate-prompt action
-                prompt: ${{ steps.prompt.outputs.prompt }}
-                # Prefer using settings.json, but some are needed to be set here for the action
-                # to automatically enable the MCP servers. Placing anything with `mcp__github__` prefix will enable the github mcp server.
-                # See https://github.com/anthropics/claude-code-action/issues/723#issuecomment-3716307305
-                # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-                # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-                # Note: We intentionally do NOT include 'github_comment' (used for Claude's persistent "working on it" comment)
-                # or 'github_inline_comment' (used for inline comments outside of reviews) in the allowed tools / claude_args,
-                # to prevent Claude from posting persistent status comments or inline comments outside of proper reviews.
-                claude_args: >-
-                  --allowedTools
-                  mcp__github__github_support_docs_search,
-                  mcp__github__get_pull_request,
-                  mcp__github__get_pull_request_diff,
-                  mcp__github__get_pull_request_files,
-                  mcp__github__get_pull_request_review_comments,
-                  mcp__github__get_pull_request_reviews,
-                  mcp__github__get_pull_request_status,
-                  mcp__github__create_pending_pull_request_review,
-                  mcp__github__add_comment_to_pending_review,
-                  mcp__github__submit_pending_pull_request_review
-
-            - id: chatroom
-              # TEMPORARY: action is hosted locally in this repo while the
-              # workflow stabilizes. Once verified, the canonical copy at
-              # nsheaps/github-actions/.github/actions/claude-stream-tail
-              # should be SHA-pinned here and the local copy removed.
-              uses: ./.github/actions/claude-stream-tail
+      # Render the just-completed Claude session as a colored chatroom view
+      # in the workflow log. Runs whether the review succeeded or failed
+      # (always()) so the session is always visible. The action finds the
+      # newest *.jsonl under ~/.claude/projects/ (the SDK's session store)
+      # and tails it through claude-stream from nsheaps/claude-utils. In
+      # this post-hoc position, the file already contains the terminal
+      # `result` message, so the action streams the whole transcript and
+      # exits cleanly.
+      #
+      # TEMPORARY: the action is hosted locally in this repo
+      # (.github/actions/claude-stream-tail) while the workflow stabilizes.
+      # Once verified, the canonical copy at
+      # nsheaps/github-actions/.github/actions/claude-stream-tail should
+      # be SHA-pinned here and the local copy removed.
+      - name: Render Claude session as chatroom view
+        if: ${{ always() && !cancelled() }}
+        uses: ./.github/actions/claude-stream-tail
+        with:
+          timeout-seconds: '120'

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -41,6 +41,17 @@ jobs:
       id-token: write
       actions: read
 
+    # Run-unique stop sentinel. The Stop hook (registered in
+    # INPUT_SETTINGS_JSON below) echoes this string when Claude finishes;
+    # the hook's stdout is recorded into the session JSONL, and the
+    # claude-stream-tail sidecar exits on it. Run-scoped via run_id +
+    # run_attempt so the resolved value never appears in any repo file
+    # (only the ${{ }} template does) -- reviewed PR content therefore
+    # cannot false-trigger an early exit. References only github.* (no
+    # steps context), so a job-level env is valid here.
+    env:
+      STOP_SENTINEL: claude-stream-session-stop-${{ github.run_id }}-${{ github.run_attempt }}
+
     steps:
       - name: Checkout and authenticate as GitHub App
         id: auth
@@ -179,6 +190,16 @@ jobs:
                 ]
               },
               "model": "opus",
+              "_HOOKS_COMMENT": "Stop hook echoes the run-unique sentinel when Claude finishes. The hook's stdout is recorded into the session JSONL as a hook_success attachment, which the claude-stream-tail sidecar detects to exit its tail cleanly instead of running to timeout. Without a registered Stop hook, the Stop event produces no JSONL record.",
+              "hooks": {
+                "Stop": [
+                  {
+                    "hooks": [
+                      { "type": "command", "command": "echo '${{ env.STOP_SENTINEL }}'" }
+                    ]
+                  }
+                ]
+              },
               "env": {
                 "GH_TOKEN": "${{ steps.auth.outputs.token }}",
                 "GITHUB_TOKEN": "${{ steps.auth.outputs.token }}",
@@ -274,6 +295,11 @@ jobs:
                 # this step's start. Safe alongside claude-code-action --
                 # ignores any pre-existing JSONL on persistent runners.
                 wait-for-new-session: 'true'
+                # Exit the tail when the Stop hook's sentinel lands in the
+                # session JSONL, instead of running to the timeout. Same
+                # run-unique value the Stop hook (INPUT_SETTINGS_JSON
+                # above) echoes.
+                stop-sentinel: ${{ env.STOP_SENTINEL }}
                 # Verified working at 6m25s in run 25956849344; keep 600s
                 # headroom for long reviews. Action default is also 600s.
                 timeout-seconds: '600'

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -238,11 +238,16 @@ jobs:
       # `result` message, so the action streams the whole transcript and
       # exits cleanly.
       #
-      # TEMPORARY: the action is hosted locally in this repo
+      # TEMPORARY: the action is hosted locally
       # (.github/actions/claude-stream-tail) while the workflow stabilizes.
-      # Once verified, the canonical copy at
-      # nsheaps/github-actions/.github/actions/claude-stream-tail should
-      # be SHA-pinned here and the local copy removed.
+      # The canonical copy at nsheaps/github-actions does NOT yet exist on
+      # main; it lives only on branch claude/stream-action-output-UtYyT and
+      # is materially different (uses a START_MARKER + find -newer filter
+      # appropriate for sidecar/parallel-steps use, which the local copy
+      # drops to support post-hoc invocation -- see action.yml comments).
+      # Resolution sequence: (1) land a unified version on
+      # nsheaps/github-actions main supporting both sidecar and post-hoc
+      # modes via an input, (2) SHA-pin it here, (3) delete this local copy.
       - name: Render Claude session as chatroom view
         if: ${{ always() && !cancelled() }}
         uses: ./.github/actions/claude-stream-tail

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -300,6 +300,9 @@ jobs:
                 # run-unique value the Stop hook (INPUT_SETTINGS_JSON
                 # above) echoes.
                 stop-sentinel: ${{ env.STOP_SENTINEL }}
-                # Verified working at 6m25s in run 25956849344; keep 600s
-                # headroom for long reviews. Action default is also 600s.
-                timeout-seconds: '600'
+                # Safety ceiling only -- with the sentinel set, the follow
+                # ends when the review's Stop hook fires. Must exceed the
+                # longest review: run 26141683146's review ran 699s and a
+                # 600s ceiling killed the follow before the Stop hook
+                # could fire. 1200s (20 min) leaves ample margin.
+                timeout-seconds: '1200'

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -90,7 +90,7 @@ jobs:
       # as Claude works. See nsheaps/github-actions/.github/actions/claude-stream-shim.
       - name: Setup Claude stream shim
         id: claude-shim
-        uses: nsheaps/github-actions/.github/actions/claude-stream-shim@ced86812fefafd46f42bc36d8147afc456374d89 # claude-stream-shim@claude/stream-action-output-UtYyT
+        uses: nsheaps/github-actions/.github/actions/claude-stream-shim@100f5b4fe8574ac8e6cb0d2dd553a09728ff46f7 # claude-stream-shim@main
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -242,6 +242,9 @@ jobs:
                 # Prompt loaded from external template via interpolate-prompt
                 # action. toJSON-wrapped for safe single-line interpolation
                 # into qoomon's embedded steps YAML (see KEY TRICK above).
+                # Same string-only caveat as `settings:` -- if the prompt
+                # output were ever an object/array (it isn't; interpolate-prompt
+                # emits a string), toJSON would emit multi-line pretty JSON.
                 prompt: ${{ toJSON(steps.prompt.outputs.prompt) }}
                 # Prefer using settings.json, but some are needed to be set here for the action
                 # to automatically enable the MCP servers. Placing anything with `mcp__github__` prefix will enable the github mcp server.

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -83,6 +83,15 @@ jobs:
         with:
           template-file: .github/prompts/claude-code-review.md
 
+      # Installs claude + claude-stream (from nsheaps/claude-utils) and emits a
+      # shim binary that tees claude's stream-json stdout through claude-stream.
+      # The action's `show_full_output: false` then suppresses the raw JSON dump
+      # while the shim renders a live colored chatroom view to the workflow log
+      # as Claude works. See nsheaps/github-actions/.github/actions/claude-stream-shim.
+      - name: Setup Claude stream shim
+        id: claude-shim
+        uses: nsheaps/github-actions/.github/actions/claude-stream-shim@ced86812fefafd46f42bc36d8147afc456374d89 # claude-stream-shim@claude/stream-action-output-UtYyT
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -179,9 +188,13 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.REVIEW_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ (secrets.REVIEW_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY) && '' || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # WARNING: PRINTS FULL JSON OUTPUT WHICH MAY INCLUDE SECRETS.
-          # ONLY USE IN PRIVATE ENVIRONMENTS.
-          show_full_output: true
+          # Raw stream-json is suppressed; the claude-stream-shim above renders
+          # a live colored chatroom view to the workflow log instead. Flip to
+          # `true` only when you also need the raw JSON for debugging (note
+          # the secret-leak warning still applies in that case).
+          show_full_output: false
+          # The shim wraps claude with a tee through claude-stream.
+          path_to_claude_code_executable: ${{ steps.claude-shim.outputs.shim-path }}
           # bug: https://github.com/anthropics/claude-code-action/issues/759
           # won't find the past comments since it's looking for github-actions[bot], not the auth it uses to post the comment.
           bot_id: ${{ steps.auth.outputs.user-id }}

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -274,4 +274,4 @@ jobs:
                 # this step's start. Safe alongside claude-code-action --
                 # ignores any pre-existing JSONL on persistent runners.
                 wait-for-new-session: 'true'
-                timeout-seconds: '1800'
+                timeout-seconds: '900'

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -41,94 +41,6 @@ jobs:
       id-token: write
       actions: read
 
-    # Job-level env. INPUT_SETTINGS_JSON lives here (not on the per-step env
-    # block as before) so it is visible to steps that the qoomon parallel
-    # action runs via `gh act`. Per-step env is set INSIDE the parallel
-    # block's `steps:` yaml below where it actually needs it.
-    env:
-      INPUT_SETTINGS_JSON: |
-        {
-          "permissions": {
-            "additionalDirectories": ["/tmp/"],
-            "allow":[
-              "Task",
-              "Glob",
-              "Grep",
-              "LS",
-              "ExitPlanMode",
-              "Read",
-              "Edit",
-              "Write",
-              "Replace",
-              "MultiEdit",
-              "NotebookRead",
-              "NotebookEdit",
-              "TodoWrite",
-              "WebSearch",
-              "WebFetch",
-              "Bash",
-              "BashOutput",
-              "KillBash",
-              "ListMcpResourcesTool",
-              "ReadMcpResourceTool",
-              "SlashCommand",
-              "Skill",
-
-              "mcp__github__github_support_docs_search",
-              "mcp__github__get_pull_request",
-              "mcp__github__get_pull_request_diff",
-              "mcp__github__get_pull_request_files",
-              "mcp__github__get_pull_request_review_comments",
-              "mcp__github__get_pull_request_reviews",
-              "mcp__github__get_pull_request_status",
-              "mcp__github__create_pending_pull_request_review",
-              "mcp__github__add_comment_to_pending_review",
-              "mcp__github__submit_pending_pull_request_review",
-
-              "Bash(git log:*)",
-              "Bash(git diff:*)",
-              "Bash(git status:*)",
-              "Bash(git rev-parse:*)",
-              "Bash(git fetch:*)",
-              "Bash(git show:*)",
-              "Bash(git merge:*)",
-              "Bash(git remote get-url:*)",
-              "Bash(git rm:*)",
-              "Bash(gh issue view:*)",
-              "Bash(gh search:*)",
-              "Bash(gh issue list:*)",
-              "Bash(gh pr comment:*)",
-              "Bash(gh pr diff:*)",
-              "Bash(gh pr view:*)",
-              "Bash(gh pr-review:*)",
-              "Bash(gh pr-review review view:*)",
-              "Bash(gh pr list:*)",
-              "Bash(gh run list:*)",
-              "Bash(gh run view:*)",
-              "Bash(gh extension list:*)"
-            ],
-            "_denyComment": "It will wait for it's own check run to complete, not to mention it should review the code.",
-            "deny": [
-              "mcp__github_ci__get_ci_status",
-              "mcp__github_ci__get_workflow_run_details",
-              "mcp__github_ci__download_job_log",
-              "Bash(gh pr checks:*)",
-              "Bash(git push:*)"
-            ]
-          },
-          "model": "opus",
-          "env": {
-            "GH_TOKEN": "${{ steps.auth.outputs.token }}",
-            "GITHUB_TOKEN": "${{ steps.auth.outputs.token }}",
-            "_GH_PAGER_COMMENT": "disable gh from being able to treat the terminal as interactive",
-            "GH_PAGER": "cat",
-            "GH_PROMPT_DISABLED": "true",
-            "_GH_BROWSER_COMMENT": "what app to open URLs with, since claude is not interactive, we use curl to pipe it to stdout",
-            "GH_BROWSER": "curl",
-            "CLAUDE_CODE_REMOTE": "true"
-          }
-        }
-
     steps:
       - name: Checkout and authenticate as GitHub App
         id: auth
@@ -194,6 +106,95 @@ jobs:
       - name: Run claude review + live chatroom (parallel)
         id: claude-review
         uses: qoomon/actions--parallel-steps@v1
+        # INPUT_SETTINGS_JSON lives here (not at job-level env) because it
+        # references steps.auth.outputs.token, which only resolves once
+        # auth has run. qoomon parallel-steps spawns its act subprocess as
+        # a child of this step's bash invocation; that child inherits this
+        # env block, so the embedded claude-code-action substep can read
+        # INPUT_SETTINGS_JSON via env. propagation.
+        env:
+          INPUT_SETTINGS_JSON: |
+            {
+              "permissions": {
+                "additionalDirectories": ["/tmp/"],
+                "allow":[
+                  "Task",
+                  "Glob",
+                  "Grep",
+                  "LS",
+                  "ExitPlanMode",
+                  "Read",
+                  "Edit",
+                  "Write",
+                  "Replace",
+                  "MultiEdit",
+                  "NotebookRead",
+                  "NotebookEdit",
+                  "TodoWrite",
+                  "WebSearch",
+                  "WebFetch",
+                  "Bash",
+                  "BashOutput",
+                  "KillBash",
+                  "ListMcpResourcesTool",
+                  "ReadMcpResourceTool",
+                  "SlashCommand",
+                  "Skill",
+
+                  "mcp__github__github_support_docs_search",
+                  "mcp__github__get_pull_request",
+                  "mcp__github__get_pull_request_diff",
+                  "mcp__github__get_pull_request_files",
+                  "mcp__github__get_pull_request_review_comments",
+                  "mcp__github__get_pull_request_reviews",
+                  "mcp__github__get_pull_request_status",
+                  "mcp__github__create_pending_pull_request_review",
+                  "mcp__github__add_comment_to_pending_review",
+                  "mcp__github__submit_pending_pull_request_review",
+
+                  "Bash(git log:*)",
+                  "Bash(git diff:*)",
+                  "Bash(git status:*)",
+                  "Bash(git rev-parse:*)",
+                  "Bash(git fetch:*)",
+                  "Bash(git show:*)",
+                  "Bash(git merge:*)",
+                  "Bash(git remote get-url:*)",
+                  "Bash(git rm:*)",
+                  "Bash(gh issue view:*)",
+                  "Bash(gh search:*)",
+                  "Bash(gh issue list:*)",
+                  "Bash(gh pr comment:*)",
+                  "Bash(gh pr diff:*)",
+                  "Bash(gh pr view:*)",
+                  "Bash(gh pr-review:*)",
+                  "Bash(gh pr-review review view:*)",
+                  "Bash(gh pr list:*)",
+                  "Bash(gh run list:*)",
+                  "Bash(gh run view:*)",
+                  "Bash(gh extension list:*)"
+                ],
+                "_denyComment": "It will wait for it's own check run to complete, not to mention it should review the code.",
+                "deny": [
+                  "mcp__github_ci__get_ci_status",
+                  "mcp__github_ci__get_workflow_run_details",
+                  "mcp__github_ci__download_job_log",
+                  "Bash(gh pr checks:*)",
+                  "Bash(git push:*)"
+                ]
+              },
+              "model": "opus",
+              "env": {
+                "GH_TOKEN": "${{ steps.auth.outputs.token }}",
+                "GITHUB_TOKEN": "${{ steps.auth.outputs.token }}",
+                "_GH_PAGER_COMMENT": "disable gh from being able to treat the terminal as interactive",
+                "GH_PAGER": "cat",
+                "GH_PROMPT_DISABLED": "true",
+                "_GH_BROWSER_COMMENT": "what app to open URLs with, since claude is not interactive, we use curl to pipe it to stdout",
+                "GH_BROWSER": "curl",
+                "CLAUDE_CODE_REMOTE": "true"
+              }
+            }
         with:
           steps: |
             - id: review

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -83,30 +83,31 @@ jobs:
         with:
           template-file: .github/prompts/claude-code-review.md
 
-      # claude-code-action runs sequentially. show_full_output: true keeps
-      # the original behavior: raw stream-json dumps to the workflow log
-      # live as Claude works. The post-hoc claude-stream-tail step below
-      # then renders the same session as a colored chatroom view -- both
-      # surfaces are visible in the run log.
+      # Runs claude-code-action and a live chatroom-view sidecar in parallel
+      # within a single job. The sidecar (claude-stream-tail) waits for the
+      # SDK to create its session JSONL under ~/.claude/projects/ and tails
+      # it through claude-stream (from nsheaps/claude-utils) so the workflow
+      # log shows a colored chatroom view as Claude works. The parallel
+      # action streams both substeps' output live into a "Concurrent logs"
+      # group (each line prefixed [N]) and also replays each substep's
+      # output in its own group at end.
       #
-      # The earlier attempt at qoomon/actions--parallel-steps + a sidecar
-      # tail action did not work: parallel-steps takes its `steps:` input
-      # as a string and re-parses it as YAML, but GitHub interpolates any
-      # multi-line ${{ }} expressions inside that string verbatim, so
-      # multi-line values (the 458-line prompt template, the multi-line
-      # settings JSON) wrecked the embedded YAML structure. Sequential is
-      # the simplest path that exercises the streaming action end-to-end.
-      - name: Run Claude Code Review
+      # show_full_output: false on claude-code-action suppresses the raw
+      # JSON dump; live signal comes from the sidecar's chatroom rendering.
+      #
+      # The two multi-line inputs (settings JSON, prompt) cannot be
+      # interpolated naively into the embedded `steps: |` block because
+      # GitHub substitutes ${{ }} verbatim before qoomon re-parses, and
+      # multi-line substitution wrecks the embedded YAML's indentation.
+      # toJSON() encodes each as a single-line JSON-quoted string, which
+      # YAML's double-quoted scalar style then decodes back to the
+      # original multi-line value inside the embedded action's inputs.
+      - name: Run claude review + live chatroom (parallel)
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: qoomon/actions--parallel-steps@v1
         env:
-          GH_TOKEN: '${{ steps.auth.outputs.token }}'
-          GITHUB_TOKEN: '${{ steps.auth.outputs.token }}'
-          # These are in addition to any parsed settings.json files
-          # Prefer this over claude_args, almost everything can be specified via settings json or env vars
-          # While Bash is allowed, the list here is passed directly to the agent, so explicitly defining them
-          # causes the agent to see those Bash commands as more relevant and will use them more often.
-          # Ref: https://code.claude.com/docs/en/settings
+          # Stored as job/step env so they can be referenced via env.X and
+          # then toJSON-encoded into the embedded YAML's single-line scalars.
           INPUT_SETTINGS_JSON: |
             {
               "permissions": {
@@ -190,66 +191,79 @@ jobs:
               }
             }
         with:
-          anthropic_api_key: ${{ secrets.REVIEW_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY || '' }}
-          claude_code_oauth_token: ${{ (secrets.REVIEW_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY) && '' || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # WARNING: PRINTS FULL JSON OUTPUT WHICH MAY INCLUDE SECRETS.
-          # ONLY USE IN PRIVATE ENVIRONMENTS. Kept ON so the workflow log
-          # has a live signal during the run; the post-hoc claude-stream-tail
-          # step below also renders a chatroom view of the same session.
-          show_full_output: true
-          # bug: https://github.com/anthropics/claude-code-action/issues/759
-          # won't find the past comments since it's looking for github-actions[bot], not the auth it uses to post the comment.
-          bot_id: ${{ steps.auth.outputs.user-id }}
-          bot_name: ${{ steps.auth.outputs.user-name }}
-          allowed_bots: 'github-actions[bot],renovate[bot],claude[bot],automation-nsheaps[bot],jack-nsheaps[bot],henry-nsheaps[bot],alex-nsheaps[bot]'
-          github_token: ${{ steps.auth.outputs.token }}
-          settings: ${{ env.INPUT_SETTINGS_JSON }}
-          additional_permissions: |
-            actions: read
-          # Prompt is loaded from external template file via interpolate-prompt action
-          prompt: ${{ steps.prompt.outputs.prompt }}
-          # Prefer using settings.json, but some are needed to be set here for the action
-          # to automatically enable the MCP servers. Placing anything with `mcp__github__` prefix will enable the github mcp server.
-          # See https://github.com/anthropics/claude-code-action/issues/723#issuecomment-3716307305
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          # Note: We intentionally do NOT include 'github_comment' (used for Claude's persistent "working on it" comment)
-          # or 'github_inline_comment' (used for inline comments outside of reviews) in the allowed tools / claude_args,
-          # to prevent Claude from posting persistent status comments or inline comments outside of proper reviews.
-          claude_args: >-
-            --allowedTools
-            mcp__github__github_support_docs_search,
-            mcp__github__get_pull_request,
-            mcp__github__get_pull_request_diff,
-            mcp__github__get_pull_request_files,
-            mcp__github__get_pull_request_review_comments,
-            mcp__github__get_pull_request_reviews,
-            mcp__github__get_pull_request_status,
-            mcp__github__create_pending_pull_request_review,
-            mcp__github__add_comment_to_pending_review,
-            mcp__github__submit_pending_pull_request_review
+          # Embedded steps for qoomon/actions--parallel-steps. The value
+          # below is a YAML literal scalar that the action re-parses as
+          # YAML internally.
+          #
+          # KEY TRICK: multi-line ${{ }} interpolation inside this scalar
+          # would break the embedded YAML's indentation. toJSON() wraps
+          # each multi-line value as a single-line JSON-quoted string with
+          # \n / \" escapes, which is a valid YAML double-quoted scalar.
+          # YAML decodes it back to the original multi-line content when
+          # qoomon re-parses, so the embedded action's `prompt:` /
+          # `settings:` inputs receive the original strings unmodified.
+          #
+          # TEMPORARY: claude-stream-tail is hosted locally
+          # (.github/actions/claude-stream-tail) while the workflow
+          # stabilizes. The canonical copy at nsheaps/github-actions does
+          # NOT yet exist on main; it lives only on branch
+          # claude/stream-action-output-UtYyT. Resolution sequence:
+          # (1) land the action on nsheaps/github-actions main with the
+          # same `wait-for-new-session` toggle, (2) SHA-pin it here, (3)
+          # delete this local copy.
+          steps: |
+            - id: review
+              uses: anthropics/claude-code-action@v1
+              env:
+                GH_TOKEN: '${{ steps.auth.outputs.token }}'
+                GITHUB_TOKEN: '${{ steps.auth.outputs.token }}'
+              with:
+                anthropic_api_key: ${{ secrets.REVIEW_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY || '' }}
+                claude_code_oauth_token: ${{ (secrets.REVIEW_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY) && '' || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+                # Raw JSON dump suppressed; live signal comes from the
+                # chatroom sidecar below instead. Also removes the prior
+                # secret-leak hazard noted in the workflow's earlier
+                # `show_full_output: true` warning.
+                show_full_output: false
+                # bug: https://github.com/anthropics/claude-code-action/issues/759
+                # won't find the past comments since it's looking for github-actions[bot], not the auth it uses to post the comment.
+                bot_id: ${{ steps.auth.outputs.user-id }}
+                bot_name: ${{ steps.auth.outputs.user-name }}
+                allowed_bots: 'github-actions[bot],renovate[bot],claude[bot],automation-nsheaps[bot],jack-nsheaps[bot],henry-nsheaps[bot],alex-nsheaps[bot]'
+                github_token: ${{ steps.auth.outputs.token }}
+                settings: ${{ toJSON(env.INPUT_SETTINGS_JSON) }}
+                additional_permissions: |
+                  actions: read
+                # Prompt loaded from external template via interpolate-prompt
+                # action. toJSON-wrapped for safe single-line interpolation
+                # into qoomon's embedded steps YAML (see KEY TRICK above).
+                prompt: ${{ toJSON(steps.prompt.outputs.prompt) }}
+                # Prefer using settings.json, but some are needed to be set here for the action
+                # to automatically enable the MCP servers. Placing anything with `mcp__github__` prefix will enable the github mcp server.
+                # See https://github.com/anthropics/claude-code-action/issues/723#issuecomment-3716307305
+                # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+                # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+                # Note: We intentionally do NOT include 'github_comment' (used for Claude's persistent "working on it" comment)
+                # or 'github_inline_comment' (used for inline comments outside of reviews) in the allowed tools / claude_args,
+                # to prevent Claude from posting persistent status comments or inline comments outside of proper reviews.
+                claude_args: >-
+                  --allowedTools
+                  mcp__github__github_support_docs_search,
+                  mcp__github__get_pull_request,
+                  mcp__github__get_pull_request_diff,
+                  mcp__github__get_pull_request_files,
+                  mcp__github__get_pull_request_review_comments,
+                  mcp__github__get_pull_request_reviews,
+                  mcp__github__get_pull_request_status,
+                  mcp__github__create_pending_pull_request_review,
+                  mcp__github__add_comment_to_pending_review,
+                  mcp__github__submit_pending_pull_request_review
 
-      # Render the just-completed Claude session as a colored chatroom view
-      # in the workflow log. Runs whether the review succeeded or failed
-      # (always()) so the session is always visible. The action finds the
-      # newest *.jsonl under ~/.claude/projects/ (the SDK's session store)
-      # and tails it through claude-stream from nsheaps/claude-utils. In
-      # this post-hoc position, the file already contains the terminal
-      # `result` message, so the action streams the whole transcript and
-      # exits cleanly.
-      #
-      # TEMPORARY: the action is hosted locally
-      # (.github/actions/claude-stream-tail) while the workflow stabilizes.
-      # The canonical copy at nsheaps/github-actions does NOT yet exist on
-      # main; it lives only on branch claude/stream-action-output-UtYyT and
-      # is materially different (uses a START_MARKER + find -newer filter
-      # appropriate for sidecar/parallel-steps use, which the local copy
-      # drops to support post-hoc invocation -- see action.yml comments).
-      # Resolution sequence: (1) land a unified version on
-      # nsheaps/github-actions main supporting both sidecar and post-hoc
-      # modes via an input, (2) SHA-pin it here, (3) delete this local copy.
-      - name: Render Claude session as chatroom view
-        if: ${{ always() && !cancelled() }}
-        uses: ./.github/actions/claude-stream-tail
-        with:
-          timeout-seconds: '120'
+            - id: chatroom
+              uses: ./.github/actions/claude-stream-tail
+              with:
+                # Sidecar mode: only pick session JSONL files newer than
+                # this step's start. Safe alongside claude-code-action --
+                # ignores any pre-existing JSONL on persistent runners.
+                wait-for-new-session: 'true'
+                timeout-seconds: '1800'

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -231,6 +231,11 @@ jobs:
                 bot_name: ${{ steps.auth.outputs.user-name }}
                 allowed_bots: 'github-actions[bot],renovate[bot],claude[bot],automation-nsheaps[bot],jack-nsheaps[bot],henry-nsheaps[bot],alex-nsheaps[bot]'
                 github_token: ${{ steps.auth.outputs.token }}
+                # toJSON() here works because INPUT_SETTINGS_JSON is a STRING
+                # (env vars always are). For an object/array value, toJSON
+                # would emit a pretty-printed multi-line JSON and reintroduce
+                # the indentation problem -- coerce to string first if you
+                # ever need to substitute a non-string here.
                 settings: ${{ toJSON(env.INPUT_SETTINGS_JSON) }}
                 additional_permissions: |
                   actions: read

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -90,7 +90,12 @@ jobs:
       # as Claude works. See nsheaps/github-actions/.github/actions/claude-stream-shim.
       - name: Setup Claude stream shim
         id: claude-shim
-        uses: nsheaps/github-actions/.github/actions/claude-stream-shim@100f5b4fe8574ac8e6cb0d2dd553a09728ff46f7 # claude-stream-shim@main
+        # TODO: re-pin to the post-merge SHA on main once
+        # nsheaps/github-actions PR (description-expression fix on
+        # claude/stream-action-output-UtYyT) is merged. The current main SHA
+        # 100f5b4 has a broken action.yml (literal ${{ }} in description
+        # rejected by the manifest parser).
+        uses: nsheaps/github-actions/.github/actions/claude-stream-shim@1e611c846262625bedff806ca7a4c8f786686a34 # claude-stream-shim@claude/stream-action-output-UtYyT
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -90,12 +90,11 @@ jobs:
       # as Claude works. See nsheaps/github-actions/.github/actions/claude-stream-shim.
       - name: Setup Claude stream shim
         id: claude-shim
-        # TODO: re-pin to the post-merge SHA on main once
-        # nsheaps/github-actions PR (description-expression fix on
-        # claude/stream-action-output-UtYyT) is merged. The current main SHA
-        # 100f5b4 has a broken action.yml (literal ${{ }} in description
-        # rejected by the manifest parser).
-        uses: nsheaps/github-actions/.github/actions/claude-stream-shim@1e611c846262625bedff806ca7a4c8f786686a34 # claude-stream-shim@claude/stream-action-output-UtYyT
+        # TODO: re-pin to a post-merge SHA on main once the
+        # claude/stream-action-output-UtYyT branch in nsheaps/github-actions
+        # is merged. Tracking the branch directly during development so
+        # iterations on the shim flow through without per-push SHA bumps.
+        uses: nsheaps/github-actions/.github/actions/claude-stream-shim@claude/stream-action-output-UtYyT
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -17,10 +17,11 @@ on:
 
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('claude-review-{0}', github.event.pull_request.number) || format('claude-review-{0}-{1}', github.ref, github.sha) }}
-  # always let a previous review finish (so that time isn't wasted), but queued builds will still
-  # be cancelled if a newer build is pushed
-  # NOTE THIS IS NOT GUARANTEED AT THE JOB LEVEL
-  cancel-in-progress: false
+  # TEMPORARILY true while iterating on the claude-stream-tail sidecar:
+  # a stuck sidecar holds the queue for the full timeout, blocking every
+  # subsequent attempt. Once verified working, flip back to false so a
+  # in-progress review isn't killed by a follow-up push.
+  cancel-in-progress: true
 
 jobs:
   claude-review:
@@ -274,4 +275,5 @@ jobs:
                 # this step's start. Safe alongside claude-code-action --
                 # ignores any pre-existing JSONL on persistent runners.
                 wait-for-new-session: 'true'
-                timeout-seconds: '900'
+                # Aggressive while iterating; bump after sidecar verified working.
+                timeout-seconds: '300'

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -239,4 +239,8 @@ jobs:
                   mcp__github__submit_pending_pull_request_review
 
             - id: chatroom
-              uses: nsheaps/github-actions/.github/actions/claude-stream-tail@claude/stream-action-output-UtYyT
+              # TEMPORARY: action is hosted locally in this repo while the
+              # workflow stabilizes. Once verified, the canonical copy at
+              # nsheaps/github-actions/.github/actions/claude-stream-tail
+              # should be SHA-pinned here and the local copy removed.
+              uses: ./.github/actions/claude-stream-tail

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -106,95 +106,6 @@ jobs:
       - name: Run claude review + live chatroom (parallel)
         id: claude-review
         uses: qoomon/actions--parallel-steps@v1
-        # INPUT_SETTINGS_JSON lives here (not at job-level env) because it
-        # references steps.auth.outputs.token, which only resolves once
-        # auth has run. qoomon parallel-steps spawns its act subprocess as
-        # a child of this step's bash invocation; that child inherits this
-        # env block, so the embedded claude-code-action substep can read
-        # INPUT_SETTINGS_JSON via env. propagation.
-        env:
-          INPUT_SETTINGS_JSON: |
-            {
-              "permissions": {
-                "additionalDirectories": ["/tmp/"],
-                "allow":[
-                  "Task",
-                  "Glob",
-                  "Grep",
-                  "LS",
-                  "ExitPlanMode",
-                  "Read",
-                  "Edit",
-                  "Write",
-                  "Replace",
-                  "MultiEdit",
-                  "NotebookRead",
-                  "NotebookEdit",
-                  "TodoWrite",
-                  "WebSearch",
-                  "WebFetch",
-                  "Bash",
-                  "BashOutput",
-                  "KillBash",
-                  "ListMcpResourcesTool",
-                  "ReadMcpResourceTool",
-                  "SlashCommand",
-                  "Skill",
-
-                  "mcp__github__github_support_docs_search",
-                  "mcp__github__get_pull_request",
-                  "mcp__github__get_pull_request_diff",
-                  "mcp__github__get_pull_request_files",
-                  "mcp__github__get_pull_request_review_comments",
-                  "mcp__github__get_pull_request_reviews",
-                  "mcp__github__get_pull_request_status",
-                  "mcp__github__create_pending_pull_request_review",
-                  "mcp__github__add_comment_to_pending_review",
-                  "mcp__github__submit_pending_pull_request_review",
-
-                  "Bash(git log:*)",
-                  "Bash(git diff:*)",
-                  "Bash(git status:*)",
-                  "Bash(git rev-parse:*)",
-                  "Bash(git fetch:*)",
-                  "Bash(git show:*)",
-                  "Bash(git merge:*)",
-                  "Bash(git remote get-url:*)",
-                  "Bash(git rm:*)",
-                  "Bash(gh issue view:*)",
-                  "Bash(gh search:*)",
-                  "Bash(gh issue list:*)",
-                  "Bash(gh pr comment:*)",
-                  "Bash(gh pr diff:*)",
-                  "Bash(gh pr view:*)",
-                  "Bash(gh pr-review:*)",
-                  "Bash(gh pr-review review view:*)",
-                  "Bash(gh pr list:*)",
-                  "Bash(gh run list:*)",
-                  "Bash(gh run view:*)",
-                  "Bash(gh extension list:*)"
-                ],
-                "_denyComment": "It will wait for it's own check run to complete, not to mention it should review the code.",
-                "deny": [
-                  "mcp__github_ci__get_ci_status",
-                  "mcp__github_ci__get_workflow_run_details",
-                  "mcp__github_ci__download_job_log",
-                  "Bash(gh pr checks:*)",
-                  "Bash(git push:*)"
-                ]
-              },
-              "model": "opus",
-              "env": {
-                "GH_TOKEN": "${{ steps.auth.outputs.token }}",
-                "GITHUB_TOKEN": "${{ steps.auth.outputs.token }}",
-                "_GH_PAGER_COMMENT": "disable gh from being able to treat the terminal as interactive",
-                "GH_PAGER": "cat",
-                "GH_PROMPT_DISABLED": "true",
-                "_GH_BROWSER_COMMENT": "what app to open URLs with, since claude is not interactive, we use curl to pipe it to stdout",
-                "GH_BROWSER": "curl",
-                "CLAUDE_CODE_REMOTE": "true"
-              }
-            }
         with:
           steps: |
             - id: review
@@ -212,7 +123,77 @@ jobs:
                 bot_name: ${{ steps.auth.outputs.user-name }}
                 allowed_bots: 'github-actions[bot],renovate[bot],claude[bot],automation-nsheaps[bot],jack-nsheaps[bot],henry-nsheaps[bot],alex-nsheaps[bot]'
                 github_token: ${{ steps.auth.outputs.token }}
-                settings: ${{ env.INPUT_SETTINGS_JSON }}
+                # Inlined here as a YAML literal scalar (NOT via env. interpolation)
+                # because qoomon/actions--parallel-steps re-parses the `steps: |`
+                # value as YAML; multi-line ${{ env.X }} substitution into the
+                # outer literal scalar would wreck this embedded YAML's
+                # indentation. ${{ steps.auth.outputs.token }} expressions inside
+                # are still evaluated by GitHub at workflow-parse time.
+                settings: |
+                  {
+                    "permissions": {
+                      "additionalDirectories": ["/tmp/"],
+                      "allow": [
+                        "Task", "Glob", "Grep", "LS", "ExitPlanMode",
+                        "Read", "Edit", "Write", "Replace", "MultiEdit",
+                        "NotebookRead", "NotebookEdit", "TodoWrite",
+                        "WebSearch", "WebFetch",
+                        "Bash", "BashOutput", "KillBash",
+                        "ListMcpResourcesTool", "ReadMcpResourceTool",
+                        "SlashCommand", "Skill",
+
+                        "mcp__github__github_support_docs_search",
+                        "mcp__github__get_pull_request",
+                        "mcp__github__get_pull_request_diff",
+                        "mcp__github__get_pull_request_files",
+                        "mcp__github__get_pull_request_review_comments",
+                        "mcp__github__get_pull_request_reviews",
+                        "mcp__github__get_pull_request_status",
+                        "mcp__github__create_pending_pull_request_review",
+                        "mcp__github__add_comment_to_pending_review",
+                        "mcp__github__submit_pending_pull_request_review",
+
+                        "Bash(git log:*)",
+                        "Bash(git diff:*)",
+                        "Bash(git status:*)",
+                        "Bash(git rev-parse:*)",
+                        "Bash(git fetch:*)",
+                        "Bash(git show:*)",
+                        "Bash(git merge:*)",
+                        "Bash(git remote get-url:*)",
+                        "Bash(git rm:*)",
+                        "Bash(gh issue view:*)",
+                        "Bash(gh search:*)",
+                        "Bash(gh issue list:*)",
+                        "Bash(gh pr comment:*)",
+                        "Bash(gh pr diff:*)",
+                        "Bash(gh pr view:*)",
+                        "Bash(gh pr-review:*)",
+                        "Bash(gh pr-review review view:*)",
+                        "Bash(gh pr list:*)",
+                        "Bash(gh run list:*)",
+                        "Bash(gh run view:*)",
+                        "Bash(gh extension list:*)"
+                      ],
+                      "_denyComment": "It will wait for it's own check run to complete, not to mention it should review the code.",
+                      "deny": [
+                        "mcp__github_ci__get_ci_status",
+                        "mcp__github_ci__get_workflow_run_details",
+                        "mcp__github_ci__download_job_log",
+                        "Bash(gh pr checks:*)",
+                        "Bash(git push:*)"
+                      ]
+                    },
+                    "model": "opus",
+                    "env": {
+                      "GH_TOKEN": "${{ steps.auth.outputs.token }}",
+                      "GITHUB_TOKEN": "${{ steps.auth.outputs.token }}",
+                      "GH_PAGER": "cat",
+                      "GH_PROMPT_DISABLED": "true",
+                      "GH_BROWSER": "curl",
+                      "CLAUDE_CODE_REMOTE": "true"
+                    }
+                  }
                 additional_permissions: |
                   actions: read
                 # Prompt is loaded from external template file via interpolate-prompt action

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -17,11 +17,10 @@ on:
 
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('claude-review-{0}', github.event.pull_request.number) || format('claude-review-{0}-{1}', github.ref, github.sha) }}
-  # TEMPORARILY true while iterating on the claude-stream-tail sidecar:
-  # a stuck sidecar holds the queue for the full timeout, blocking every
-  # subsequent attempt. Once verified working, flip back to false so a
-  # in-progress review isn't killed by a follow-up push.
-  cancel-in-progress: true
+  # always let a previous review finish (so that time isn't wasted), but queued builds will still
+  # be cancelled if a newer build is pushed
+  # NOTE THIS IS NOT GUARANTEED AT THE JOB LEVEL
+  cancel-in-progress: false
 
 jobs:
   claude-review:
@@ -275,5 +274,6 @@ jobs:
                 # this step's start. Safe alongside claude-code-action --
                 # ignores any pre-existing JSONL on persistent runners.
                 wait-for-new-session: 'true'
-                # Aggressive while iterating; bump after sidecar verified working.
-                timeout-seconds: '300'
+                # Verified working at 6m25s in run 25956849344; keep 600s
+                # headroom for long reviews. Action default is also 600s.
+                timeout-seconds: '600'

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -41,6 +41,94 @@ jobs:
       id-token: write
       actions: read
 
+    # Job-level env. INPUT_SETTINGS_JSON lives here (not on the per-step env
+    # block as before) so it is visible to steps that the qoomon parallel
+    # action runs via `gh act`. Per-step env is set INSIDE the parallel
+    # block's `steps:` yaml below where it actually needs it.
+    env:
+      INPUT_SETTINGS_JSON: |
+        {
+          "permissions": {
+            "additionalDirectories": ["/tmp/"],
+            "allow":[
+              "Task",
+              "Glob",
+              "Grep",
+              "LS",
+              "ExitPlanMode",
+              "Read",
+              "Edit",
+              "Write",
+              "Replace",
+              "MultiEdit",
+              "NotebookRead",
+              "NotebookEdit",
+              "TodoWrite",
+              "WebSearch",
+              "WebFetch",
+              "Bash",
+              "BashOutput",
+              "KillBash",
+              "ListMcpResourcesTool",
+              "ReadMcpResourceTool",
+              "SlashCommand",
+              "Skill",
+
+              "mcp__github__github_support_docs_search",
+              "mcp__github__get_pull_request",
+              "mcp__github__get_pull_request_diff",
+              "mcp__github__get_pull_request_files",
+              "mcp__github__get_pull_request_review_comments",
+              "mcp__github__get_pull_request_reviews",
+              "mcp__github__get_pull_request_status",
+              "mcp__github__create_pending_pull_request_review",
+              "mcp__github__add_comment_to_pending_review",
+              "mcp__github__submit_pending_pull_request_review",
+
+              "Bash(git log:*)",
+              "Bash(git diff:*)",
+              "Bash(git status:*)",
+              "Bash(git rev-parse:*)",
+              "Bash(git fetch:*)",
+              "Bash(git show:*)",
+              "Bash(git merge:*)",
+              "Bash(git remote get-url:*)",
+              "Bash(git rm:*)",
+              "Bash(gh issue view:*)",
+              "Bash(gh search:*)",
+              "Bash(gh issue list:*)",
+              "Bash(gh pr comment:*)",
+              "Bash(gh pr diff:*)",
+              "Bash(gh pr view:*)",
+              "Bash(gh pr-review:*)",
+              "Bash(gh pr-review review view:*)",
+              "Bash(gh pr list:*)",
+              "Bash(gh run list:*)",
+              "Bash(gh run view:*)",
+              "Bash(gh extension list:*)"
+            ],
+            "_denyComment": "It will wait for it's own check run to complete, not to mention it should review the code.",
+            "deny": [
+              "mcp__github_ci__get_ci_status",
+              "mcp__github_ci__get_workflow_run_details",
+              "mcp__github_ci__download_job_log",
+              "Bash(gh pr checks:*)",
+              "Bash(git push:*)"
+            ]
+          },
+          "model": "opus",
+          "env": {
+            "GH_TOKEN": "${{ steps.auth.outputs.token }}",
+            "GITHUB_TOKEN": "${{ steps.auth.outputs.token }}",
+            "_GH_PAGER_COMMENT": "disable gh from being able to treat the terminal as interactive",
+            "GH_PAGER": "cat",
+            "GH_PROMPT_DISABLED": "true",
+            "_GH_BROWSER_COMMENT": "what app to open URLs with, since claude is not interactive, we use curl to pipe it to stdout",
+            "GH_BROWSER": "curl",
+            "CLAUDE_CODE_REMOTE": "true"
+          }
+        }
+
     steps:
       - name: Checkout and authenticate as GitHub App
         id: auth
@@ -83,150 +171,71 @@ jobs:
         with:
           template-file: .github/prompts/claude-code-review.md
 
-      # Installs claude + claude-stream (from nsheaps/claude-utils) and emits a
-      # shim binary that tees claude's stream-json stdout through claude-stream.
-      # The action's `show_full_output: false` then suppresses the raw JSON dump
-      # while the shim renders a live colored chatroom view to the workflow log
-      # as Claude works. See nsheaps/github-actions/.github/actions/claude-stream-shim.
-      - name: Setup Claude stream shim
-        id: claude-shim
-        # TODO: re-pin to a post-merge SHA on main once the
-        # claude/stream-action-output-UtYyT branch in nsheaps/github-actions
-        # is merged. Tracking the branch directly during development so
-        # iterations on the shim flow through without per-push SHA bumps.
-        uses: nsheaps/github-actions/.github/actions/claude-stream-shim@claude/stream-action-output-UtYyT
-
-      - name: Run Claude Code Review
+      # Runs claude-code-action and a live chatroom-view sidecar in parallel
+      # within the same job. The sidecar (claude-stream-tail) waits for the
+      # SDK to create its session JSONL under ~/.claude/projects/ and tails
+      # it through claude-stream (from nsheaps/claude-utils) so the workflow
+      # log shows a colored chatroom view as Claude works. The parallel
+      # action streams both substeps' output live into a "Concurrent logs"
+      # group (each line prefixed [N]) and also replays each substep's
+      # output in its own group at end.
+      #
+      # claude-code-action@v1 calls the Claude Agent SDK in-process and no
+      # longer spawns the claude CLI, so a CLI-wrapper approach (the prior
+      # claude-stream-shim) is a no-op against v1. Tailing the SDK session
+      # file is the SDK-friendly equivalent.
+      #
+      # show_full_output: false suppresses the raw JSON dump in the
+      # claude-code-action substep's output; the live chatroom comes from
+      # the sidecar's stdout/stderr instead.
+      # TODO: re-pin nsheaps/github-actions references to post-merge SHAs
+      # on main once claude/stream-action-output-UtYyT merges. Branch ref
+      # used during development so shim/tail iterations flow through.
+      - name: Run claude review + live chatroom (parallel)
         id: claude-review
-        uses: anthropics/claude-code-action@v1
-        env:
-          GH_TOKEN: '${{ steps.auth.outputs.token }}'
-          GITHUB_TOKEN: '${{ steps.auth.outputs.token }}'
-          # These are in addition to any parsed settings.json files
-          # Prefer this over claude_args, almost everything can be specified via settings json or env vars
-          # While Bash is allowed, the list here is passed directly to the agent, so explicitly defining them
-          # causes the agent to see those Bash commands as more relevant and will use them more often.
-          # Ref: https://code.claude.com/docs/en/settings
-          INPUT_SETTINGS_JSON: |
-            {
-              "permissions": {
-                "additionalDirectories": ["/tmp/"],
-                "allow":[
-                  "Task",
-                  "Glob",
-                  "Grep",
-                  "LS",
-                  "ExitPlanMode",
-                  "Read",
-                  "Edit",
-                  "Write",
-                  "Replace",
-                  "MultiEdit",
-                  "NotebookRead",
-                  "NotebookEdit",
-                  "TodoWrite",
-                  "WebSearch",
-                  "WebFetch",
-                  "Bash",
-                  "BashOutput",
-                  "KillBash",
-                  "ListMcpResourcesTool",
-                  "ReadMcpResourceTool",
-                  "SlashCommand",
-                  "Skill",
-
-                  "mcp__github__github_support_docs_search",
-                  "mcp__github__get_pull_request",
-                  "mcp__github__get_pull_request_diff",
-                  "mcp__github__get_pull_request_files",
-                  "mcp__github__get_pull_request_review_comments",
-                  "mcp__github__get_pull_request_reviews",
-                  "mcp__github__get_pull_request_status",
-                  "mcp__github__create_pending_pull_request_review",
-                  "mcp__github__add_comment_to_pending_review",
-                  "mcp__github__submit_pending_pull_request_review",
-
-                  "Bash(git log:*)",
-                  "Bash(git diff:*)",
-                  "Bash(git status:*)",
-                  "Bash(git rev-parse:*)",
-                  "Bash(git fetch:*)",
-                  "Bash(git show:*)",
-                  "Bash(git merge:*)",
-                  "Bash(git remote get-url:*)",
-                  "Bash(git rm:*)",
-                  "Bash(gh issue view:*)",
-                  "Bash(gh search:*)",
-                  "Bash(gh issue list:*)",
-                  "Bash(gh pr comment:*)",
-                  "Bash(gh pr diff:*)",
-                  "Bash(gh pr view:*)",
-                  "Bash(gh pr-review:*)",
-                  "Bash(gh pr-review review view:*)",
-                  "Bash(gh pr list:*)",
-                  "Bash(gh run list:*)",
-                  "Bash(gh run view:*)",
-                  "Bash(gh extension list:*)"
-                ],
-                "_denyComment": "It will wait for it's own check run to complete, not to mention it should review the code.",
-                "deny": [
-                  "mcp__github_ci__get_ci_status",
-                  "mcp__github_ci__get_workflow_run_details",
-                  "mcp__github_ci__download_job_log",
-                  "Bash(gh pr checks:*)",
-                  "Bash(git push:*)"
-                ]
-              },
-              "model": "opus",
-              "env": {
-                "GH_TOKEN": "${{ steps.auth.outputs.token }}",
-                "GITHUB_TOKEN": "${{ steps.auth.outputs.token }}",
-                "_GH_PAGER_COMMENT": "disable gh from being able to treat the terminal as interactive",
-                "GH_PAGER": "cat",
-                "GH_PROMPT_DISABLED": "true",
-                "_GH_BROWSER_COMMENT": "what app to open URLs with, since claude is not interactive, we use curl to pipe it to stdout",
-                "GH_BROWSER": "curl",
-                "CLAUDE_CODE_REMOTE": "true"
-              }
-            }
+        uses: qoomon/actions--parallel-steps@v1
         with:
-          anthropic_api_key: ${{ secrets.REVIEW_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY || '' }}
-          claude_code_oauth_token: ${{ (secrets.REVIEW_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY) && '' || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Raw stream-json is suppressed; the claude-stream-shim above renders
-          # a live colored chatroom view to the workflow log instead. Flip to
-          # `true` only when you also need the raw JSON for debugging (note
-          # the secret-leak warning still applies in that case).
-          show_full_output: false
-          # The shim wraps claude with a tee through claude-stream.
-          path_to_claude_code_executable: ${{ steps.claude-shim.outputs.shim-path }}
-          # bug: https://github.com/anthropics/claude-code-action/issues/759
-          # won't find the past comments since it's looking for github-actions[bot], not the auth it uses to post the comment.
-          bot_id: ${{ steps.auth.outputs.user-id }}
-          bot_name: ${{ steps.auth.outputs.user-name }}
-          allowed_bots: 'github-actions[bot],renovate[bot],claude[bot],automation-nsheaps[bot],jack-nsheaps[bot],henry-nsheaps[bot],alex-nsheaps[bot]'
-          github_token: ${{ steps.auth.outputs.token }}
-          settings: ${{ env.INPUT_SETTINGS_JSON }}
-          additional_permissions: |
-            actions: read
-          # Prompt is loaded from external template file via interpolate-prompt action
-          prompt: ${{ steps.prompt.outputs.prompt }}
-          # Prefer using settings.json, but some are needed to be set here for the action
-          # to automatically enable the MCP servers. Placing anything with `mcp__github__` prefix will enable the github mcp server.
-          # See https://github.com/anthropics/claude-code-action/issues/723#issuecomment-3716307305
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          # Note: We intentionally do NOT include 'github_comment' (used for Claude's persistent "working on it" comment)
-          # or 'github_inline_comment' (used for inline comments outside of reviews) in the allowed tools / claude_args,
-          # to prevent Claude from posting persistent status comments or inline comments outside of proper reviews.
-          claude_args: >-
-            --allowedTools
-            mcp__github__github_support_docs_search,
-            mcp__github__get_pull_request,
-            mcp__github__get_pull_request_diff,
-            mcp__github__get_pull_request_files,
-            mcp__github__get_pull_request_review_comments,
-            mcp__github__get_pull_request_reviews,
-            mcp__github__get_pull_request_status,
-            mcp__github__create_pending_pull_request_review,
-            mcp__github__add_comment_to_pending_review,
-            mcp__github__submit_pending_pull_request_review
+          steps: |
+            - id: review
+              uses: anthropics/claude-code-action@v1
+              env:
+                GH_TOKEN: '${{ steps.auth.outputs.token }}'
+                GITHUB_TOKEN: '${{ steps.auth.outputs.token }}'
+              with:
+                anthropic_api_key: ${{ secrets.REVIEW_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY || '' }}
+                claude_code_oauth_token: ${{ (secrets.REVIEW_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY) && '' || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+                show_full_output: false
+                # bug: https://github.com/anthropics/claude-code-action/issues/759
+                # won't find the past comments since it's looking for github-actions[bot], not the auth it uses to post the comment.
+                bot_id: ${{ steps.auth.outputs.user-id }}
+                bot_name: ${{ steps.auth.outputs.user-name }}
+                allowed_bots: 'github-actions[bot],renovate[bot],claude[bot],automation-nsheaps[bot],jack-nsheaps[bot],henry-nsheaps[bot],alex-nsheaps[bot]'
+                github_token: ${{ steps.auth.outputs.token }}
+                settings: ${{ env.INPUT_SETTINGS_JSON }}
+                additional_permissions: |
+                  actions: read
+                # Prompt is loaded from external template file via interpolate-prompt action
+                prompt: ${{ steps.prompt.outputs.prompt }}
+                # Prefer using settings.json, but some are needed to be set here for the action
+                # to automatically enable the MCP servers. Placing anything with `mcp__github__` prefix will enable the github mcp server.
+                # See https://github.com/anthropics/claude-code-action/issues/723#issuecomment-3716307305
+                # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+                # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+                # Note: We intentionally do NOT include 'github_comment' (used for Claude's persistent "working on it" comment)
+                # or 'github_inline_comment' (used for inline comments outside of reviews) in the allowed tools / claude_args,
+                # to prevent Claude from posting persistent status comments or inline comments outside of proper reviews.
+                claude_args: >-
+                  --allowedTools
+                  mcp__github__github_support_docs_search,
+                  mcp__github__get_pull_request,
+                  mcp__github__get_pull_request_diff,
+                  mcp__github__get_pull_request_files,
+                  mcp__github__get_pull_request_review_comments,
+                  mcp__github__get_pull_request_reviews,
+                  mcp__github__get_pull_request_status,
+                  mcp__github__create_pending_pull_request_review,
+                  mcp__github__add_comment_to_pending_review,
+                  mcp__github__submit_pending_pull_request_review
+
+            - id: chatroom
+              uses: nsheaps/github-actions/.github/actions/claude-stream-tail@claude/stream-action-output-UtYyT


### PR DESCRIPTION


> ## What
>
> Adds a live, colored "chatroom" view of the Claude Code review session to the `claude-code-review` workflow log, replacing the raw stream-json dump.
>
> A new in-repo composite action — `.github/actions/claude-stream-tail` — runs as a parallel sidecar to `anthropics/claude-code-action@v1` via `qoomon/actions--parallel-steps@v1`. It tails the Claude Agent SDK's session JSONL under `~/.claude/projects/` through `claude-stream` (from `nsheaps/claude-utils`) and renders it as a chatroom view. `show_full_output: false` suppresses the raw JSON dump.
>
> ## Why
>
> The raw stream-json output is verbose, hard to read, and carries a secret-leak risk (previously gated behind a `show_full_output: true` warning). The chatroom view is a readable real-time signal during the run; suppressing the raw dump removes the leak hazard.
>
> `claude-code-action@v1` calls the Claude Agent SDK in-process and no longer spawns the `claude` CLI, so a CLI-wrapper ("shim") approach is impossible against v1 — hence the sidecar-tails-the-JSONL design.
>
> ## How
>
> 1. **Parallel sidecar.** `qoomon/actions--parallel-steps@v1` runs `claude-code-action` and `claude-stream-tail` concurrently in one job; both substeps' output streams into a "Concurrent logs" group live.
> 2. **Multi-line input encoding.** `parallel-steps` re-parses its `steps:` input as YAML; naive multi-line `${{ }}` substitution would break the embedded indentation. `settings` and `prompt` are wrapped with `toJSON()` — single-line JSON-quoted strings that YAML decodes back to the originals on re-parse.
> 3. **Clean sidecar exit.** A Claude Code `Stop` hook echoes a run-unique sentinel; its stdout is recorded into the session JSONL. `claude-stream --exit-on-session-stop` (new flag) ends the tail the moment the sentinel appears, instead of running to a timeout. A `timeout` still bounds the follow as a safety net.
>
> ## Dependencies
>
> Requires `claude-stream --exit-on-session-stop`, added in `nsheaps/claude-utils` (branch `claude/stream-action-output-UtYyT`). The action installs claude-utils from that branch until the flag ships on a release tag.
>
> ## Temporary state
>
> `claude-stream-tail` is hosted in-repo. Canonical home is `nsheaps/github-actions`; once landed there it will be SHA-pinned and the local copy deleted (the workflow TODO documents the 3-step sequence).
>
> ## Test plan
>
> - [x] `claude-stream --exit-on-session-stop` unit-tested locally — matching sentinel exits 0; no-flag / non-matching sentinel follow to timeout; stdin, `--file`, and `--no-follow` modes all pass
> - [x] Workflow end-to-end: run `26142278001` — parallel block 421s, sidecar exited on the Stop-hook sentinel well under the 1200s ceiling, conclusion success
> - [x] `ci` green on the branch

