### PR TITLE
docs(claude-builtins): investigate live usage/cost data, fix nNb/rNb naming

### DIFF
--- a/plugins/claude-builtins/README.md
+++ b/plugins/claude-builtins/README.md
@@ -10,12 +10,14 @@ all — how agent-to-agent messaging is actually wired
 (`skills/agent-messaging/`), and how the plugin/skill reload triggers work
 (`docs/reload-mechanisms.md`).
 
-**Provenance is per asset, not per plugin.** Each asset carries the binary
-version it was extracted from, in the file itself. A mixed-version tree is the
-expected steady state — re-extracting one asset shouldn't force a rewrite of
-every other stamp. Today the command prompts are **v2.1.225**, the
-agent-messaging mechanics are **v2.1.226**, and the reload-mechanisms
-investigation is **v2.1.223**;
+**Provenance is per asset, not per plugin — and a single file can carry more
+than one stamp.** Each fact carries the binary version it was checked
+against, at its source. A mixed-version tree is the expected steady state —
+re-extracting one asset shouldn't force a rewrite of every other stamp, and
+`skills/usage/SKILL.md` itself mixes **v2.1.225** (the weight formula) with
+**v2.1.226** (the live-data investigation added later) in the same file.
+Today the command prompts are **v2.1.225**, the agent-messaging mechanics are
+**v2.1.226**, and the reload-mechanisms investigation is **v2.1.223**;
 `grep -rnE 'v[0-9]+\.[0-9]+\.[0-9]+' plugins/claude-builtins/` is the
 authoritative answer at any point in time.
 
@@ -109,7 +111,12 @@ drop-in. When both are present, invoke this one explicitly as
 > backed by server-side plan/limit and cost data that a plugin cannot recompute.
 > What follows is a local, approximate analysis of your transcripts — an
 > approximation of the built-in's "what's contributing to your limits usage?"
-> section only, never a headline cost and never USD.
+> section only, never a headline cost and never USD. This was checked against
+> the binary, not assumed: the CLI does cache its last live fetch locally
+> (`cachedUsageUtilization` in `~/.claude.json`, 5-minute TTL), but this skill
+> doesn't read it — that file also holds real OAuth account state, and parsing
+> it from a plugin script is a different trust boundary than parsing your own
+> transcripts. See `skills/usage/SKILL.md` for the full investigation.
 
 ```bash
 /usage                     # this session (most recent in the current project)
@@ -125,7 +132,7 @@ formula, recovered verbatim from the binary:
 
 ```
 weight = (cache_read + input*10 + cache_creation*12.5 + output*50) * modelTier
-modelTier:  fable = 10,  opus = 5,  haiku = 1,  default = 3
+modelTier:  fable = 10,  opus = 5,  haiku = 1,  sonnet (default) = 3
 ```
 
 Requests are deduped by `requestId` / message `uuid` so retries and streamed

--- a/plugins/claude-builtins/scripts/collect-usage.mjs
+++ b/plugins/claude-builtins/scripts/collect-usage.mjs
@@ -17,11 +17,18 @@
 // weighted usage went: by model, by tool, by sub-agent / skill / plugin / MCP
 // server, and main-vs-subagent.
 //
-// The weight is the binary's own internal relative unit (fns nNb × rNb), and is
-// NEVER dollars and never the number `/usage` shows as a headline:
+// The weight is the binary's own internal relative unit — a per-request weight
+// function (binary: nNb) applied to a per-model-tier multiplier (binary: rNb) —
+// and is NEVER dollars and never the number `/usage` shows as a headline:
 //   weight = (cache_read + input*10 + cache_creation*12.5 + output*50) * modelTier
-//   modelTier: fable=10, opus=5, haiku=1, default=3
+//   modelTier: fable=10, opus=5, haiku=1, sonnet (default)=3
 // Requests are de-duplicated by requestId/uuid, matching the binary's local scan.
+//
+// A separate binary field, additionalModelCostsCache (fn Ims, default table
+// _mt), looks like a real USD price table but isn't: it holds these same
+// relative-weight rates. Genuine dollar cost only exists server-side, in the
+// GET /api/oauth/usage response (its schema includes a `currency` field this
+// weight table doesn't) — there is no local, token-count-only path to it.
 //
 // Coverage note: the binary's local section reports five behaviors —
 // cache_miss, long_context, subagent_heavy, high_parallel, and cron. This script
@@ -57,12 +64,13 @@ import {
 } from "./lib/transcripts.mjs";
 
 // ---------------------------------------------------------------------------
-// Relative-weight model (verbatim from the binary: nNb / rNb). This is the
-// binary's INTERNAL weighting for the local "contributing factors" section —
-// a relative unit, never USD, never the `/usage` headline number.
+// Relative-weight model, verbatim from the binary's per-request weight
+// function (nNb) and per-model-tier multiplier (rNb). This is the binary's
+// INTERNAL weighting for the local "contributing factors" section — a
+// relative unit, never USD, never the `/usage` headline number.
 // ---------------------------------------------------------------------------
 
-/** modelTier: fable=10, opus=5, haiku=1, default=3 (binary: rNb) */
+/** Per-model-tier multiplier: fable=10, opus=5, haiku=1, sonnet (default)=3. Binary: rNb. */
 function modelTier(model) {
   if (!model) return 3;
   const t = model.toLowerCase();
@@ -479,7 +487,7 @@ async function main() {
       '"What\'s contributing to your limits usage?" section. It is NOT USD and ' +
       "NOT the utilization/cost numbers /usage shows (those come from Claude's " +
       "servers and cannot be reproduced here). Model tiers: fable=10, opus=5, " +
-      "haiku=1, default=3. Weighting: cache_read×1, input×10, cache_creation×12.5, " +
+      "haiku=1, sonnet (default)=3. Weighting: cache_read×1, input×10, cache_creation×12.5, " +
       "output×50. Behaviors computed here: cache_miss, long_context only " +
       "(subagent_heavy, high_parallel, cron are NOT computed).",
     totals: {

--- a/plugins/claude-builtins/skills/usage/SKILL.md
+++ b/plugins/claude-builtins/skills/usage/SKILL.md
@@ -24,6 +24,25 @@ server (`GET /api/oauth/usage`) and renders reset times, percentages, and cost.
 None of that server data — the numbers users actually go to `/usage` for — is
 available to a plugin, so none of it is reproduced here.
 
+**This was investigated, not assumed** (checked against binary **v2.1.226**).
+The binary does cache its last fetch of
+that endpoint locally, under `cachedUsageUtilization` in `~/.claude.json`
+(`fetchedAtMs`, `accountUuid`, and the raw response — percent/reset-time per
+rate-limit bucket, keyed roughly `five_hour`/`seven_day`/`seven_day_opus`/
+`seven_day_sonnet`), refreshed on a 5-minute TTL (binary constant `fe_`). A
+sibling field, `cachedExtraUsageDisabledReason`, records whether overage is
+currently disabled and why. This skill deliberately does **not** read either
+one: `~/.claude.json` sits alongside real OAuth account state
+(`oauthAccount`, per-model cost overrides) in the same file, its schema is
+undocumented and unversioned, and a plugin script silently parsing it is a
+different trust boundary than parsing your own session transcripts — which is
+why this repo's own permission classifier pushes back on touching that file
+at all. Calling `GET /api/oauth/usage` directly has the same shape of problem
+one layer up: it needs the CLI's own OAuth access token, which isn't reliably
+readable as a portable, refreshable credential from outside the CLI process.
+If you want the real numbers, run the built-in `/usage` — that's what it's
+for.
+
 What this skill _can_ stand in for is one section of that TUI: **"What's
 contributing to your limits usage?"** The built-in ranks contributors using an
 internal relative weight computed from local token counts. This skill computes
@@ -41,12 +60,28 @@ Two halves:
 
 The built-in's local "contributing factors" section does **not** rank by USD. It
 ranks by an internal relative weight derived from token counts. That weight
-formula is extracted verbatim from the binary (`nNb` × `rNb`):
+formula is extracted verbatim from the binary — a per-request weight function
+(binary symbol `nNb`) applied to a per-model-tier multiplier (binary symbol
+`rNb`):
 
 ```
 weight = (cache_read + input*10 + cache_creation*12.5 + output*50) * modelTier
-modelTier:  fable = 10,  opus = 5,  haiku = 1,  default = 3
+modelTier:  fable = 10,  opus = 5,  haiku = 1,  sonnet (default) = 3
 ```
+
+Every model that isn't fable/opus/haiku — sonnet included — falls under
+`default`; the binary has no separate sonnet-specific tier.
+
+**This is also not the same thing as real dollar cost**, and the binary
+confirms why: a similarly-named binary field, `additionalModelCostsCache`
+(server-provided per-model overrides, function `Ims`/binary default table
+`_mt`), turns out to hold the _same_ relative-weight rates shown above
+(`{inputTokens:10, outputTokens:50, promptCacheWriteTokens:12.5,
+promptCacheReadTokens:1, ...}`) — not USD. The real per-account dollar figure
+lives only in the `GET /api/oauth/usage` response (which carries a `currency`
+field this weight table doesn't), so there is no local, token-count-only path
+to a genuine cost number. This skill's weight breakdown is the closest local
+stand-in for "where did the cost go" that can be computed offline.
 
 This is a **relative unit only** — it is meaningful for comparing contributors
 against each other, not as an absolute cost. It is **not dollars**, and it is
@@ -177,12 +212,18 @@ the figures are auditable.
 
 ## Notes on fidelity
 
-- The **weight formula** (`nNb` × `rNb`) is verbatim from the binary
-  (v2.1.225) and is the genuine relative unit the local "contributing factors"
-  section ranks by. Everything else the built-in `/usage` shows — plan/limit
-  utilization %, reset windows, real cost — is server-fetched and **cannot** be
-  reproduced by a plugin. Do not present this skill's output as the built-in's
-  output.
+- The **weight formula** (per-request weight function `nNb` × per-model-tier
+  multiplier `rNb`) is verbatim from the binary (v2.1.225) and is the genuine
+  relative unit the local "contributing factors" section ranks by. It is
+  distinct from `additionalModelCostsCache`/`_mt` (function `Ims`; checked
+  against v2.1.226), which looked like a real cost table on first read but
+  turns out to hold the same relative-weight rates, not USD — see "The
+  relative-weight unit" above.
+  Everything the built-in `/usage` shows that genuinely is dollar-denominated
+  — plan/limit utilization %, reset windows, real cost — is server-fetched
+  (`GET /api/oauth/usage`, response schema includes a `currency` field) and
+  **cannot** be reproduced by a plugin. Do not present this skill's output as
+  the built-in's output.
 - Only `cacheMiss` and `longContext` behaviors are computed;
   `subagent_heavy`, `high_parallel`, and `cron` are not.
 


### PR DESCRIPTION
Follow-up to #711 (merged) — addresses review comments left on `skills/usage/SKILL.md` after that PR had already merged, so they couldn't land there.

## What

- **"Did you try tokens in `~/.claude.json`?"** — investigated against the real `v2.1.226` binary rather than assumed. The CLI does cache its last `GET /api/oauth/usage` fetch locally (`cachedUsageUtilization`, 5-minute TTL via binary constant `fe_`) plus `cachedExtraUsageDisabledReason`. Documented in `skills/usage/SKILL.md` exactly where the question was asked, along with why this plugin deliberately does **not** read either field: `~/.claude.json` sits alongside real OAuth account state in the same file, its schema is undocumented/unversioned, and a plugin script silently parsing it is a different trust boundary than parsing session transcripts — confirmed empirically, since this repo's own permission classifier repeatedly blocked even read-only inspection of that file during the investigation. A direct live API call has the same shape of problem one layer up: no portable, refreshable OAuth token is reliably readable outside the CLI process.
- **"The transcripts should also call out cost"** — investigated and found the local path doesn't exist: `additionalModelCostsCache`/`_mt` (function `Ims`) looks like a real USD price table on first read, but turns out to hold the *same* relative-weight rates the plugin already implements (`nNb`/`rNb`), not dollars. Real cost is only ever server-side, in the `GET /api/oauth/usage` response (whose schema includes a `currency` field this weight table doesn't). Documented this distinction directly rather than silently declining the ask.
- Replaced bare `nNb`/`rNb` binary-symbol references with descriptive names (per-request weight function / per-model-tier multiplier), keeping the raw symbols as secondary provenance annotations rather than the primary label a reader sees.
- The `modelTier` table now names **sonnet** explicitly under `default` (weight 3) instead of leaving the mapping implicit.
- Stamped the new `v2.1.226` findings distinctly from the file's existing `v2.1.225` weight-formula stamp (per-asset provenance, not per-file), and updated the README's provenance paragraph to note `skills/usage/SKILL.md` now mixes both versions in one file.

## Why

`nsheaps` left these as review comments on PR #711 (`skills/usage/SKILL.md`), but they arrived around the same time auto-merge landed the PR, so there was no way to push a fix to that branch. This PR carries the same branch name forward from a fresh `main`, per this repo's convention for follow-up work after a merge.

## Scope note — what this PR does *not* do

The original ask was "try not to use the cache if the api works, only use it as a fallback." I investigated that path first and found real, concrete obstacles: no primary OAuth token accessible as a portable, readable credential in at least this session type (only per-MCP-server tokens were present, and those were empty), outbound HTTPS here goes through a proxy that wouldn't carry the CLI's internal auth the same way, and the permission classifier consistently pushed back on inspecting `~/.claude.json` at all — including plain `ls`/`stat`-level checks, not just credential extraction. Given that, I scoped this down to documenting what was found rather than shipping code that reads either the live API or the local credential-adjacent cache file. Happy to revisit if there's a safer mechanism I'm missing (e.g. a documented, scriptable `claude` subcommand that already handles auth internally).

## Validation

- [x] `node --check` clean on `collect-usage.mjs`
- [x] `prettier --check` clean across the plugin
- [x] End-to-end: `collect-usage.mjs --all --json` still runs correctly and the `note` field now says `sonnet (default)=3`
- [x] Provenance grep (`grep -rnE 'v[0-9]+\.[0-9]+\.[0-9]+' plugins/claude-builtins/`) picks up both the `v2.1.225` and new `v2.1.226` stamps in `skills/usage/SKILL.md`

## Additional Context

Modifies `plugins/claude-builtins/README.md`, `plugins/claude-builtins/scripts/collect-usage.mjs`, and `plugins/claude-builtins/skills/usage/SKILL.md` only.

Related: #711 (the original PR these comments were left on, merged).


---
_Generated by [Claude Code](https://claude.ai/code/session_01SHrQ3YVRrh7X1gmEJQPkqH)_