### PR TITLE
feat(direnv): add direnv plugin for per-directory env loading

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -311,6 +311,26 @@
       "keywords": ["discord", "messaging", "channel", "mcp"]
     },
     {
+      "name": "direnv",
+      "description": "Install and manage direnv (per-directory environment loader) in Claude Code sessions. Computes the .envrc env diff once via `direnv export bash` at session start and re-computes it before Bash calls when .envrc changes — never installs direnv's shell hook.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Nathan Heaps"
+      },
+      "source": "./plugins/direnv",
+      "category": "utility",
+      "tags": ["utility", "skill", "session-start", "auto-install"],
+      "keywords": [
+        "direnv",
+        "envrc",
+        "environment",
+        "session-start",
+        "pre-tool-use",
+        "auto-install",
+        "env-vars"
+      ]
+    },
+    {
       "name": "edit-utils",
       "description": "File editing utilities: auto-formatting and linting for written/edited files with project-aware configuration",
       "version": "0.1.0",

--- a/plugins/direnv/.claude-plugin/plugin.json
+++ b/plugins/direnv/.claude-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "direnv",
+  "version": "0.1.0",
+  "description": "Install and manage direnv (per-directory environment loader) in Claude Code sessions. Computes the .envrc env diff once via `direnv export bash` at session start and re-computes it before Bash calls when .envrc changes — never installs direnv's shell hook.",
+  "author": {
+    "name": "Nathan Heaps",
+    "email": "nsheaps@gmail.com",
+    "url": "https://github.com/nsheaps"
+  },
+  "homepage": "https://github.com/nsheaps/ai-mktpl/tree/main/plugins/direnv",
+  "repository": "https://github.com/nsheaps/ai-mktpl",
+  "keywords": [
+    "direnv",
+    "envrc",
+    "environment",
+    "session-start",
+    "pre-tool-use",
+    "auto-install",
+    "env-vars"
+  ],
+  "dependencies": [
+    {
+      "name": "shared-lib",
+      "version": "^1.0"
+    }
+  ]
+}

--- a/plugins/direnv/.release-it.js
+++ b/plugins/direnv/.release-it.js
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: "../../.release-it.base.json",
+  plugins: {
+    "@release-it/bumper": {
+      in: ".claude-plugin/plugin.json",
+      out: ".claude-plugin/plugin.json",
+    },
+  },
+};

--- a/plugins/direnv/README.md
+++ b/plugins/direnv/README.md
@@ -13,6 +13,7 @@ direnv's interactive shell hook.
 - **Auto-allow**: Runs `direnv allow` for the project's `.envrc` (and any git worktrees) so the export step doesn't get silently blocked
 - **One-shot export, not a shell hook**: Computes the `.envrc` diff via `direnv export bash` and writes it as static `export`/`unset` statements — see [Why not `direnv hook bash`?](#why-not-direnv-hook-bash) below
 - **Change-aware PreToolUse hook**: Re-computes the diff before `Bash` calls, but only when the `.envrc` fingerprint (path + mtime + size) has actually changed, debounced to avoid re-checking on every single call
+- **claude-utils integration (enhancement, not required)**: uses [nsheaps/claude-utils](https://github.com/nsheaps/claude-utils)' `agent-plugin`/`agent-hook` binaries when they're on PATH — see [claude-utils integration](#claude-utils-integration-agent-plugin--agent-hook) below
 
 ## How It Works
 
@@ -30,6 +31,22 @@ direnv's own documented shell integration (`eval "$(direnv hook bash)"`) install
 3. It overrides `cd`/`pushd`/`popd`, adding overhead that's unnecessary in a non-interactive agent shell that already gets `CLAUDE_ENV_FILE` re-sourced by the harness
 
 Instead, this plugin runs `direnv export bash` **directly** (never via `eval` inside `CLAUDE_ENV_FILE`), captures its output once, and writes it as a static snapshot. The snapshot is only regenerated when the `PreToolUse` hook detects the `.envrc` state actually changed.
+
+## claude-utils integration (`agent-plugin` / `agent-hook`)
+
+[nsheaps/claude-utils](https://github.com/nsheaps/claude-utils) ships two native binaries meant for exactly this kind of plugin: `agent-plugin` (logging, per-plugin settings, `ensure-dependency`) and `agent-hook` (parses a hook's JSON stdin, emits its decision). This plugin uses both **opportunistically, not as a hard dependency** — install with `brew install nsheaps/devsetup/claude-utils` to opt in; everything below still works without it.
+
+- **Install** (`install-direnv.sh`): when `agent-plugin` is on PATH, tries `agent-plugin ensure-dependency direnv "direnv@latest"` first (installs via `mise use -g direnv@latest` — the mise registry resolves the bare name `direnv` to the `aqua:direnv/direnv` backend). On **any** failure — `agent-plugin` absent, its own `autoInstall` setting declined, no `mise`, or the mise install itself failing — falls back to the direct GitHub-release download that has always been this plugin's install mechanism.
+- **Logging**: when `agent-plugin` is on PATH, routes log messages through `agent-plugin log-*` (level-filterable via `$AGENT_PLUGIN_LOG_LEVEL`) in addition to this repo's own `hook-logging.sh` lifecycle (which SessionStart's summary output and failure diagnostics still depend on either way).
+- **PreToolUse input parsing** (`direnv-check.sh`): when `agent-hook` is on PATH, uses `agent-hook export-input` instead of hand-rolled `jq` parsing to read `tool_name`/`tool_input.command` from the hook payload. Falls back to `jq` otherwise. This hook never calls `agent-hook allow`/`deny` for its "nothing changed" case — per this repo's [hook-output-patterns.md](../../.claude/rules/hook-output-patterns.md), a PreToolUse hook with no opinion must emit nothing at all, not an explicit `allow` (which would bypass the normal permission system for every `Bash` call).
+
+### Why an enhancement, not a hard dependency
+
+`agent-plugin`'s settings (`.claude/settings.direnv.yaml`, one file per plugin) are a **different file** from this plugin's own `direnv.settings.yaml`/`plugins.settings.yaml` convention (read via `shared-lib`'s `plugin-config-read.sh`, the convention every other ai-mktpl plugin uses). Requiring both to be configured to get auto-install working would be a regression for the plugin's existing settings story, and no other ai-mktpl plugin depends on claude-utils yet. So `direnv.settings.yaml`'s own `autoInstall` remains the single source of truth for _whether_ to install at all; `agent-plugin`/`mise` is only an alternate _mechanism_, tried first when available, with the original curl-based download as the unconditional fallback.
+
+### Debounce/throttle — pending upstream extraction
+
+The `PreToolUse` hook's debounce (`should_check`/`record_check` in `direnv-check.sh`) is a local `DEBOUNCE_FILE` + elapsed-seconds implementation, the same pattern originally written inline in the `github-app` plugin. [nsheaps/claude-utils#436](https://github.com/nsheaps/claude-utils/pull/436) (branch `feature/agent-hook-throttle`) generalizes this into a reusable `bin/lib/agent-hook-throttle.sh` (`throttle_should_run`/`throttle_record`). Once that PR merges and ships in a release, `direnv-check.sh` should swap to sourcing it — the local functions are deliberately isolated so that swap is a one-function change, not a rewrite.
 
 ## Configuration
 

--- a/plugins/direnv/README.md
+++ b/plugins/direnv/README.md
@@ -1,0 +1,88 @@
+# direnv
+
+Install and manage [direnv](https://direnv.net) (per-directory environment loader) in Claude Code sessions.
+
+direnv loads project-scoped environment variables from an `.envrc` file when
+you `cd` into a directory. This plugin makes those variables available to
+every `Bash` tool call in a Claude Code session — **without** installing
+direnv's interactive shell hook.
+
+## Features
+
+- **Auto-install**: Downloads the direnv binary to `$CLAUDE_PROJECT_DIR/bin/.local/` when not already on PATH
+- **Auto-allow**: Runs `direnv allow` for the project's `.envrc` (and any git worktrees) so the export step doesn't get silently blocked
+- **One-shot export, not a shell hook**: Computes the `.envrc` diff via `direnv export bash` and writes it as static `export`/`unset` statements — see [Why not `direnv hook bash`?](#why-not-direnv-hook-bash) below
+- **Change-aware PreToolUse hook**: Re-computes the diff before `Bash` calls, but only when the `.envrc` fingerprint (path + mtime + size) has actually changed, debounced to avoid re-checking on every single call
+
+## How It Works
+
+1. **Session starts**: installs direnv if needed, runs `direnv allow` on `.envrc`, then runs `direnv export bash` once and writes the result to `$CLAUDE_PLUGIN_DATA/direnv-env`
+2. **`CLAUDE_ENV_FILE` wiring**: a single `source "$CLAUDE_PLUGIN_DATA/direnv-env"` line is added to `CLAUDE_ENV_FILE` (idempotent — added once), so every subsequent `Bash` call picks up the current snapshot
+3. **Before each `Bash` call**: the `PreToolUse` hook checks (debounced) whether the nearest `.envrc` has changed. If so, it re-runs `direnv export bash` and **overwrites** `direnv-env` in place, so vars removed from `.envrc` are correctly dropped, not just left stale
+4. **Directory awareness**: the `PreToolUse` hook makes a best-effort attempt to detect a `cd <dir> &&` prefix in the Bash command to resolve the "current" directory before looking for `.envrc`; if none is found it falls back to `$CLAUDE_PROJECT_DIR`
+
+## Why not `direnv hook bash`?
+
+direnv's own documented shell integration (`eval "$(direnv hook bash)"`) installs a `PROMPT_COMMAND`-style hook that re-runs on **every** shell command. That pattern causes the same problems this repo's `mise` plugin avoids (see `plugins/mise/hooks/scripts/install-mise.sh`):
+
+1. direnv can write status/error text to stderr (and in some configurations, stdout) on every command — polluting command output
+2. If that output were ever `eval`'d, it becomes an eval-injection risk
+3. It overrides `cd`/`pushd`/`popd`, adding overhead that's unnecessary in a non-interactive agent shell that already gets `CLAUDE_ENV_FILE` re-sourced by the harness
+
+Instead, this plugin runs `direnv export bash` **directly** (never via `eval` inside `CLAUDE_ENV_FILE`), captures its output once, and writes it as a static snapshot. The snapshot is only regenerated when the `PreToolUse` hook detects the `.envrc` state actually changed.
+
+## Configuration
+
+Create or update `plugins.settings.yaml` at project or user level:
+
+```yaml
+# In $CLAUDE_PROJECT_DIR/.claude/plugins.settings.yaml
+# or ~/.claude/plugins.settings.yaml
+
+direnv:
+  enabled: true # Enable/disable the plugin
+  autoInstall: true # Download direnv if not on PATH
+  installToProject: true # Install to $project/bin/.local (vs ~/.local/bin)
+  backgroundInstall: false # Run install in background
+  version: "latest" # Pin a specific version or use "latest"
+  autoAllow: true # Run `direnv allow` for .envrc on session start
+  checkIntervalSeconds: 2 # Debounce interval for the PreToolUse .envrc check
+```
+
+## On-disk Layout
+
+All files are written under `$CLAUDE_PLUGIN_DATA/` (per-agent isolated):
+
+```
+$CLAUDE_PLUGIN_DATA/
+├── direnv-env            # Runtime env file (static export/unset statements), sourced via CLAUDE_ENV_FILE
+├── direnv-fingerprint     # path:mtime:size of the last-exported .envrc
+└── direnv-last-check      # Debounce timestamp for the PreToolUse check
+```
+
+## Plugin Structure
+
+```
+plugins/direnv/
+├── .claude-plugin/plugin.json
+├── hooks/
+│   ├── hooks.json
+│   └── scripts/
+│       ├── install-direnv.sh   # SessionStart: install, allow, initial export
+│       └── direnv-check.sh     # PreToolUse (Bash): debounced re-export on .envrc change
+├── lib/
+│   └── direnv-export.sh        # Shared: platform detection, fingerprinting, export+write
+├── skills/
+│   └── direnv/SKILL.md         # Manual-operation reference
+└── README.md
+```
+
+## Limitations
+
+- The `PreToolUse` hook cannot see the persistent Bash shell's actual current directory — it makes a best-effort guess by parsing a leading `cd <dir> &&`/`cd <dir>;` from the command, falling back to `$CLAUDE_PROJECT_DIR`. Deeply nested `cd`s inside a script, or directory changes via other means, are not tracked.
+- direnv must have already been `allow`ed for a given `.envrc` (handled automatically for the project dir and worktrees at session start when `autoAllow: true`). A brand-new `.envrc` created mid-session in a directory the plugin hasn't seen before will need an explicit `direnv allow` — see the `direnv` skill for the manual procedure.
+
+## Related
+
+- **[mise](../mise)** — tool version manager; follows the same "static export, no shell hook" discipline
+- **[shared-lib](../shared-lib)** — bash helper libraries this plugin depends on

--- a/plugins/direnv/SPEC.md
+++ b/plugins/direnv/SPEC.md
@@ -1,0 +1,12 @@
+# Plugin: direnv
+
+**Purpose**: Install and manage [direnv](https://direnv.net) (per-directory environment loader) in Claude Code sessions.
+
+## Skills
+
+- `direnv` — Use this skill when the user asks about managing per-directory environment variables, working with .envrc, understanding why direnv env vars aren't loaded, or any task involving direnv.
+
+## Hooks
+
+- `SessionStart` (`bash`) — Install direnv, run `direnv allow`, and compute the `.envrc` diff once via `direnv export bash` into `CLAUDE_ENV_FILE`.
+- `PreToolUse` (`bash`, matcher `Bash`) — Debounced check of the `.envrc` fingerprint; re-exports only when it changed.

--- a/plugins/direnv/direnv.settings.yaml
+++ b/plugins/direnv/direnv.settings.yaml
@@ -1,0 +1,39 @@
+# direnv plugin configuration
+#
+# Override per-project via ${CLAUDE_PROJECT_DIR}/.claude/plugins.settings.yaml
+# or per-user via ~/.claude/plugins.settings.yaml under the "direnv" key.
+#
+# Set enabled: false to disable auto-install and env sync without uninstalling
+# the plugin.
+
+direnv:
+  enabled: true
+
+  # Download and install the direnv binary if not already on PATH.
+  # Set to false when direnv is managed externally (e.g. by mise or Homebrew).
+  # The plugin will still export .envrc into CLAUDE_ENV_FILE when direnv is
+  # found on PATH.
+  autoInstall: true
+
+  # Install direnv to $CLAUDE_PROJECT_DIR/bin/.local. Only used when
+  # autoInstall is true.
+  installToProject: true
+
+  # Run installation in the background (non-blocking session start).
+  backgroundInstall: false
+
+  # Specific direnv version to install (default: latest).
+  # version: "2.37.1"
+  version: 'latest'
+
+  # Run `direnv allow` for .envrc in the project dir (and any git worktrees)
+  # on session start, so the diff can be exported without a manual approval
+  # step. direnv normally refuses to load an .envrc it hasn't seen approved.
+  autoAllow: true
+
+  # Minimum seconds between PreToolUse .envrc state checks (debounce/throttle).
+  # The PreToolUse hook only re-runs `direnv export bash` when this interval
+  # has elapsed AND the .envrc fingerprint (path + mtime + size) has changed.
+  # See hooks/scripts/direnv-check.sh for the local `should_check` seam that
+  # a shared "agent-hook throttle" helper is expected to replace later.
+  checkIntervalSeconds: 2

--- a/plugins/direnv/hooks/hooks.json
+++ b/plugins/direnv/hooks/hooks.json
@@ -1,0 +1,29 @@
+{
+  "description": "direnv lifecycle: install + compute .envrc diff on session start, re-export before Bash calls when .envrc changes",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/install-direnv.sh",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/direnv-check.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/direnv/hooks/scripts/direnv-check.sh
+++ b/plugins/direnv/hooks/scripts/direnv-check.sh
@@ -11,6 +11,18 @@
 # has an opinion about allow/deny, so it NEVER writes a permissionDecision.
 # It always exits 0 with empty stdout, deferring to the normal permission
 # system. Status is logged to stderr only.
+#
+# Input parsing prefers claude-utils' `agent-hook export-input` (when
+# `agent-hook` is on PATH) over hand-rolled jq, falling back to jq
+# otherwise — see lib/direnv-export.sh for why this is an enhancement, not a
+# hard dependency. NOTE: this hook deliberately does NOT call `agent-hook
+# allow`/`deny` for its "nothing changed" case — per this repo's own
+# hook-output-patterns.md, a PreToolUse hook with no opinion must emit
+# NOTHING, not an explicit allow (an explicit allow bypasses the normal
+# permission system for every single Bash call, which this hook must never
+# do). agent-hook's decision subcommands are used only where this hook
+# actually needs to speak, which today is never — it only ever re-exports
+# state and stays silent.
 set -euo pipefail
 
 PLUGIN_NAME="direnv"
@@ -52,9 +64,29 @@ source "${CLAUDE_PLUGIN_ROOT}/lib/direnv-export.sh"
 plugin_is_enabled || { hook_respond; exit 0; }
 
 # --- Read hook input ---
+#
+# Prefer agent-hook's parser (exports HOOK_TOOL_NAME, HOOK_TOOL_INPUT_COMMAND,
+# etc. — see that repo's export-input.ts for the injection-safety guarantees
+# it gives the eval below). Fall back to jq when agent-hook isn't on PATH.
 
 INPUT="$(cat)"
-TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)"
+
+AGENT_HOOK_BIN="$(direnv_agent_hook_bin)"
+AGENT_HOOK_EXPORTS=""
+if [ -n "$AGENT_HOOK_BIN" ]; then
+  AGENT_HOOK_EXPORTS="$("$AGENT_HOOK_BIN" export-input "$INPUT" 2>/dev/null || true)"
+fi
+
+if [ -n "$AGENT_HOOK_EXPORTS" ]; then
+  eval "$AGENT_HOOK_EXPORTS"
+  TOOL_NAME="${HOOK_TOOL_NAME:-}"
+  CMD="${HOOK_TOOL_INPUT_COMMAND:-}"
+else
+  # agent-hook not on PATH, or (unexpectedly) failed to parse the payload —
+  # fall back to jq so this hook keeps working either way.
+  TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)"
+  CMD="$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)"
+fi
 
 # Belt-and-suspenders: hooks.json already matches only Bash, but guard here
 # too in case the matcher is ever widened to "*".
@@ -70,11 +102,8 @@ fi
 # prefix (a common pattern for this agent's own Bash calls), honor it;
 # otherwise fall back to CLAUDE_PROJECT_DIR, matching what SessionStart used.
 resolve_target_dir() {
-  local cmd
-  cmd="$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)"
-
   local cd_target
-  cd_target="$(echo "$cmd" | sed -nE 's/^[[:space:]]*cd[[:space:]]+("[^"]+"|'"'"'[^'"'"']+'"'"'|[^[:space:]&;]+).*/\1/p' | head -1)"
+  cd_target="$(echo "$CMD" | sed -nE 's/^[[:space:]]*cd[[:space:]]+("[^"]+"|'"'"'[^'"'"']+'"'"'|[^[:space:]&;]+).*/\1/p' | head -1)"
   # Strip surrounding quotes if present
   cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
   cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
@@ -95,12 +124,20 @@ TARGET_DIR="$(resolve_target_dir)"
 
 # --- Debounce/throttle ---
 #
-# TODO(agent-hook-throttle): this local debounce is a placeholder. A
-# companion task is extracting this exact "DEBOUNCE_FILE + elapsed seconds"
-# pattern (first introduced in github-app's github-token-check.sh) into a
-# shared, reusable helper in claude-utils. should_check()/record_check() are
-# kept as small, isolated functions specifically so that swap is a
-# one-function change here, not a rewrite of this script.
+# TODO(agent-hook-throttle): this local debounce is a placeholder. Confirmed
+# in-flight: nsheaps/claude-utils PR #436
+# (https://github.com/nsheaps/claude-utils/pull/436, branch
+# feature/agent-hook-throttle) generalizes this exact "DEBOUNCE_FILE +
+# elapsed seconds" pattern (first introduced in github-app's
+# github-token-check.sh) into `bin/lib/agent-hook-throttle.sh`
+# (throttle_should_run/throttle_record, sourceable) plus a CLI wrapper. Once
+# #436 merges and ships in a claude-utils release, replace should_check()/
+# record_check() below with a source of that library and calls to
+# `throttle_should_run "direnv-envrc-check" "$DEBOUNCE_SECONDS"
+# "$CLAUDE_PLUGIN_DATA"` / `throttle_record "direnv-envrc-check"
+# "$CLAUDE_PLUGIN_DATA"` — same signature shape, so this is a one-function
+# swap, not a rewrite. should_check()/record_check() are kept as small,
+# isolated functions specifically so that swap stays localized.
 DEBOUNCE_FILE="${CLAUDE_PLUGIN_DATA}/direnv-last-check"
 DEBOUNCE_SECONDS="$(plugin_get_config "checkIntervalSeconds" "2")"
 
@@ -146,13 +183,13 @@ elif [ -x "${CLAUDE_PROJECT_DIR:-.}/bin/.local/direnv" ]; then
 fi
 
 if [ -z "$DIRENV_BIN" ]; then
-  hook_log "direnv binary not found (PATH or bin/.local) — skipping re-export"
+  direnv_log "warn" "direnv binary not found (PATH or bin/.local) — skipping re-export"
   hook_log_cleanup
   hook_respond
   exit 0
 fi
 
-hook_log "envrc fingerprint changed, re-exporting via direnv"
+direnv_log "info" "envrc fingerprint changed, re-exporting via direnv"
 direnv_export_and_write "$DIRENV_BIN" "$TARGET_DIR" "$RUNTIME_FILE"
 echo "$CURRENT_FP" > "$FINGERPRINT_FILE"
 

--- a/plugins/direnv/hooks/scripts/direnv-check.sh
+++ b/plugins/direnv/hooks/scripts/direnv-check.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# direnv-check.sh — PreToolUse hook for direnv plugin
+#
+# Runs before each Bash tool call (see hooks/hooks.json matcher). Re-checks
+# whether the nearest .envrc has changed (added, removed, or modified) and,
+# if so, re-runs `direnv export bash` and rewrites the static runtime env
+# file that CLAUDE_ENV_FILE sources. Debounced/throttled so this does not
+# stat the filesystem and diff .envrc state on literally every tool call.
+#
+# Output rules (see .claude/rules/hook-output-patterns.md): this hook never
+# has an opinion about allow/deny, so it NEVER writes a permissionDecision.
+# It always exits 0 with empty stdout, deferring to the normal permission
+# system. Status is logged to stderr only.
+set -euo pipefail
+
+PLUGIN_NAME="direnv"
+
+# --- Source shared libs (same resolution as install-direnv.sh) ---
+
+if [ -n "${CLAUDE_PLUGIN_DATA:-}" ]; then
+  SHARED_LIB_DIR="${CLAUDE_PLUGIN_DATA%/*}/shared-lib-ai-mktpl/lib"
+else
+  SHARED_LIB_DIR="${HOME}/.claude/plugins/data/shared-lib-ai-mktpl/lib"
+fi
+
+_wait_for_shared_lib() {
+  local lib="$1"
+  local i=0
+  while [ ! -f "$SHARED_LIB_DIR/$lib" ]; do
+    i=$((i + 1))
+    if [ "$i" -ge 20 ]; then
+      echo "[$PLUGIN_NAME] timed out waiting for $SHARED_LIB_DIR/$lib (shared-lib SessionStart copy)" >&2
+      exit 0
+    fi
+    sleep 0.5
+  done
+}
+
+_wait_for_shared_lib "plugin-config-read.sh"
+_wait_for_shared_lib "hook-logging.sh"
+
+# shellcheck source=/dev/null
+source "$SHARED_LIB_DIR/plugin-config-read.sh"
+# shellcheck source=/dev/null
+source "$SHARED_LIB_DIR/hook-logging.sh"
+
+# shellcheck source=../../lib/direnv-export.sh
+source "${CLAUDE_PLUGIN_ROOT}/lib/direnv-export.sh"
+
+# --- Guards ---
+
+plugin_is_enabled || { hook_respond; exit 0; }
+
+# --- Read hook input ---
+
+INPUT="$(cat)"
+TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)"
+
+# Belt-and-suspenders: hooks.json already matches only Bash, but guard here
+# too in case the matcher is ever widened to "*".
+if [ "$TOOL_NAME" != "Bash" ]; then
+  hook_respond
+  exit 0
+fi
+
+# --- Resolve target directory ---
+#
+# Best-effort: a persistent Bash tool shell's actual cwd isn't visible to a
+# hook process. If the command starts with a `cd <dir> &&`/`cd <dir>;`
+# prefix (a common pattern for this agent's own Bash calls), honor it;
+# otherwise fall back to CLAUDE_PROJECT_DIR, matching what SessionStart used.
+resolve_target_dir() {
+  local cmd
+  cmd="$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)"
+
+  local cd_target
+  cd_target="$(echo "$cmd" | sed -nE 's/^[[:space:]]*cd[[:space:]]+("[^"]+"|'"'"'[^'"'"']+'"'"'|[^[:space:]&;]+).*/\1/p' | head -1)"
+  # Strip surrounding quotes if present
+  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
+  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+
+  if [ -n "$cd_target" ]; then
+    local resolved
+    resolved="$(cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null && cd "$cd_target" 2>/dev/null && pwd)" || resolved=""
+    if [ -n "$resolved" ]; then
+      echo "$resolved"
+      return 0
+    fi
+  fi
+
+  echo "${CLAUDE_PROJECT_DIR:-.}"
+}
+
+TARGET_DIR="$(resolve_target_dir)"
+
+# --- Debounce/throttle ---
+#
+# TODO(agent-hook-throttle): this local debounce is a placeholder. A
+# companion task is extracting this exact "DEBOUNCE_FILE + elapsed seconds"
+# pattern (first introduced in github-app's github-token-check.sh) into a
+# shared, reusable helper in claude-utils. should_check()/record_check() are
+# kept as small, isolated functions specifically so that swap is a
+# one-function change here, not a rewrite of this script.
+DEBOUNCE_FILE="${CLAUDE_PLUGIN_DATA}/direnv-last-check"
+DEBOUNCE_SECONDS="$(plugin_get_config "checkIntervalSeconds" "2")"
+
+should_check() {
+  [ -f "$DEBOUNCE_FILE" ] || return 0
+  local last_check now elapsed
+  last_check="$(cat "$DEBOUNCE_FILE" 2>/dev/null || echo 0)"
+  now="$(date +%s)"
+  elapsed=$((now - last_check))
+  [ "$elapsed" -ge "$DEBOUNCE_SECONDS" ]
+}
+
+record_check() {
+  mkdir -p "$(dirname "$DEBOUNCE_FILE")"
+  date +%s > "$DEBOUNCE_FILE"
+}
+
+# --- Main ---
+
+should_check || { hook_respond; exit 0; }
+record_check
+
+FINGERPRINT_FILE="${CLAUDE_PLUGIN_DATA}/direnv-fingerprint"
+RUNTIME_FILE="${CLAUDE_PLUGIN_DATA}/direnv-env"
+
+CURRENT_FP="$(direnv_fingerprint "$TARGET_DIR")"
+STORED_FP=""
+[ -f "$FINGERPRINT_FILE" ] && STORED_FP="$(cat "$FINGERPRINT_FILE" 2>/dev/null || echo "")"
+
+if [ "$CURRENT_FP" = "$STORED_FP" ]; then
+  # No .envrc change — nothing to do, stay silent.
+  hook_respond
+  exit 0
+fi
+
+# .envrc state changed (added, removed, modified, or a different ancestor
+# .envrc now applies because the target directory changed). Re-export.
+DIRENV_BIN=""
+if command -v direnv &>/dev/null; then
+  DIRENV_BIN="$(command -v direnv)"
+elif [ -x "${CLAUDE_PROJECT_DIR:-.}/bin/.local/direnv" ]; then
+  DIRENV_BIN="${CLAUDE_PROJECT_DIR:-.}/bin/.local/direnv"
+fi
+
+if [ -z "$DIRENV_BIN" ]; then
+  hook_log "direnv binary not found (PATH or bin/.local) — skipping re-export"
+  hook_log_cleanup
+  hook_respond
+  exit 0
+fi
+
+hook_log "envrc fingerprint changed, re-exporting via direnv"
+direnv_export_and_write "$DIRENV_BIN" "$TARGET_DIR" "$RUNTIME_FILE"
+echo "$CURRENT_FP" > "$FINGERPRINT_FILE"
+
+hook_log_cleanup
+hook_respond

--- a/plugins/direnv/hooks/scripts/install-direnv.sh
+++ b/plugins/direnv/hooks/scripts/install-direnv.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# install-direnv.sh — SessionStart hook for direnv plugin
+#
+# Installs/updates direnv, then computes the .envrc env diff ONCE via
+# `direnv export bash` and writes it as STATIC export statements to a
+# runtime env file that is sourced via CLAUDE_ENV_FILE.
+#
+# IMPORTANT: We deliberately do NOT install `direnv hook bash` (the
+# PROMPT_COMMAND-style shell hook). That hook re-invokes
+# `direnv export bash` via `eval` on every single shell prompt, which causes
+# the same class of problems documented at length in mise's install-mise.sh:
+#   1. direnv can write status/error output (e.g. "direnv: loading .envrc")
+#      to stderr on every command, and some versions/configs leak text to
+#      stdout too — polluting command output.
+#   2. Any stray stdout from the hook gets `eval`'d as bash, which is an
+#      eval-injection risk if an .envrc (or a bug in direnv) ever emits
+#      unexpected text.
+#   3. The hook overrides cd/pushd/popd to re-run on every directory change,
+#      which is unnecessary overhead in a non-interactive agent shell.
+#
+# Instead: `direnv export bash` is run exactly once here (at session start),
+# and again only when the PreToolUse hook (direnv-check.sh) detects the
+# .envrc fingerprint has changed. See lib/direnv-export.sh for the shared
+# implementation and further rationale.
+set -euo pipefail
+
+PLUGIN_NAME="direnv"
+
+# --- Source shared libs from shared-lib plugin's persistent data dir ---
+#
+# shared-lib (declared in plugin.json `dependencies`) copies its lib/*.sh
+# files into ${CLAUDE_PLUGIN_DATA}/lib on SessionStart. We resolve its data
+# dir by stripping our own data-dir name and appending shared-lib's id.
+# Plugin data dir IDs are deterministic: `{plugin-name}-{marketplace-name}`.
+# See https://code.claude.com/docs/en/plugins-reference#persistent-data-directory
+#
+# When CLAUDE_PLUGIN_DATA is unset (e.g. when this script is invoked
+# outside a Claude Code hook), fall back to the known path.
+if [ -n "${CLAUDE_PLUGIN_DATA:-}" ]; then
+  SHARED_LIB_DIR="${CLAUDE_PLUGIN_DATA%/*}/shared-lib-ai-mktpl/lib"
+else
+  SHARED_LIB_DIR="${HOME}/.claude/plugins/data/shared-lib-ai-mktpl/lib"
+fi
+
+_wait_for_shared_lib() {
+  local lib="$1"
+  local i=0
+  while [ ! -f "$SHARED_LIB_DIR/$lib" ]; do
+    i=$((i + 1))
+    if [ "$i" -ge 20 ]; then
+      echo "[$PLUGIN_NAME] timed out waiting for $SHARED_LIB_DIR/$lib (shared-lib SessionStart copy)" >&2
+      exit 1
+    fi
+    sleep 0.5
+  done
+}
+
+_wait_for_shared_lib "plugin-config-read.sh"
+_wait_for_shared_lib "tool-install.sh"
+_wait_for_shared_lib "hook-logging.sh"
+_wait_for_shared_lib "env-file.sh"
+
+# shellcheck source=/dev/null
+source "$SHARED_LIB_DIR/plugin-config-read.sh"
+# shellcheck source=/dev/null
+source "$SHARED_LIB_DIR/tool-install.sh"
+# shellcheck source=/dev/null
+source "$SHARED_LIB_DIR/hook-logging.sh"
+# shellcheck source=/dev/null
+source "$SHARED_LIB_DIR/env-file.sh"
+
+# --- Plugin-local lib (fingerprint + export helpers shared with PreToolUse hook) ---
+# shellcheck source=../../lib/direnv-export.sh
+source "${CLAUDE_PLUGIN_ROOT}/lib/direnv-export.sh"
+
+# --- Guards ---
+
+plugin_is_enabled || { hook_log "plugin disabled, skipping"; hook_respond; exit 0; }
+
+# --- Read config ---
+
+version="$(plugin_get_config "version" "latest")"
+auto_install="$(plugin_get_config "autoInstall" "true")"
+auto_allow="$(plugin_get_config "autoAllow" "true")"
+
+tool_resolve_install_dir
+
+# --- Resolve direnv binary ---
+
+resolve_direnv_bin() {
+  hook_log_step "resolve-direnv" "Resolving direnv binary"
+  local direnv_bin="$INSTALL_DIR/direnv"
+
+  if [ "$auto_install" != "true" ]; then
+    if tool_is_available direnv; then
+      hook_log "autoInstall=false, using direnv from PATH at $(command -v direnv)"
+      command -v direnv
+      return 0
+    fi
+    hook_log "autoInstall=false and direnv not on PATH, skipping"
+    return 1
+  fi
+
+  if [ -x "$direnv_bin" ]; then
+    hook_log "direnv already installed at $direnv_bin"
+    echo "$direnv_bin"
+    return 0
+  fi
+
+  if tool_is_available direnv; then
+    direnv_bin="$(command -v direnv)"
+    hook_log "direnv found on PATH at $direnv_bin"
+    echo "$direnv_bin"
+    return 0
+  fi
+
+  direnv_detect_platform || return 1
+
+  local target_version="$version"
+  if [ "$target_version" = "latest" ]; then
+    target_version="$(tool_resolve_github_version "direnv/direnv" "2.37.1")"
+  fi
+
+  # Asset naming verified against a live GitHub release (v2.37.1): direnv
+  # publishes a bare, unversioned executable per platform — no "v" prefix,
+  # no archive. e.g. direnv.linux-amd64, direnv.darwin-arm64.
+  local asset="direnv.${DIRENV_OS}-${DIRENV_ARCH}"
+  local url="https://github.com/direnv/direnv/releases/download/v${target_version}/${asset}"
+
+  hook_log_step "download-direnv" "Downloading direnv v${target_version} from ${url}"
+  if curl -fsSL "$url" -o "$direnv_bin" 2>/dev/null; then
+    chmod +x "$direnv_bin"
+    hook_log "direnv v${target_version} installed to ${direnv_bin}"
+    echo "$direnv_bin"
+    return 0
+  fi
+
+  hook_fail "direnv download" "Failed to download direnv v${target_version} from ${url}" \
+    "Check network connectivity, or set version to a specific release in plugin settings"
+  return 1
+}
+
+# --- Auto-allow: trust .envrc in project dir and any git worktrees ---
+#
+# direnv refuses to load an .envrc it hasn't seen `direnv allow`ed (a
+# security feature, mirroring mise's `mise trust`). Without this, the export
+# step below silently produces nothing for a fresh/unapproved .envrc.
+auto_allow_envrc() {
+  local direnv_bin="$1"
+  [ "$auto_allow" = "true" ] || { hook_log "autoAllow=false, skipping direnv allow"; return 0; }
+
+  local project_dir
+  project_dir="$(cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null && pwd)" || project_dir="${CLAUDE_PROJECT_DIR:-.}"
+  local allowed_any=false
+
+  if [ -f "${project_dir}/.envrc" ]; then
+    hook_log_step "allow-envrc" "Allowing ${project_dir}/.envrc"
+    "$direnv_bin" allow "${project_dir}/.envrc" || true
+    allowed_any=true
+  fi
+
+  if command -v git &>/dev/null; then
+    while IFS= read -r worktree_dir; do
+      if [ "$worktree_dir" != "$project_dir" ] && [ -f "${worktree_dir}/.envrc" ]; then
+        hook_log "Allowing worktree ${worktree_dir}/.envrc"
+        "$direnv_bin" allow "${worktree_dir}/.envrc" || true
+        allowed_any=true
+      fi
+    done < <(git -C "$project_dir" worktree list --porcelain 2>/dev/null | grep "^worktree " | sed 's/^worktree //')
+  fi
+
+  if [ "$allowed_any" = "false" ]; then
+    hook_log "No .envrc found to allow (looked in ${project_dir})"
+  fi
+}
+
+# --- Main ---
+
+do_setup() {
+  local direnv_bin
+  direnv_bin="$(resolve_direnv_bin)" || { hook_respond; exit 0; }
+
+  tool_ensure_path "$INSTALL_DIR"
+
+  auto_allow_envrc "$direnv_bin"
+
+  local project_dir="${CLAUDE_PROJECT_DIR:-.}"
+  local runtime_file="${CLAUDE_PLUGIN_DATA}/direnv-env"
+  local fingerprint_file="${CLAUDE_PLUGIN_DATA}/direnv-fingerprint"
+
+  hook_log_step "export-envrc" "Computing .envrc diff via 'direnv export bash'"
+  direnv_export_and_write "$direnv_bin" "$project_dir" "$runtime_file"
+  direnv_fingerprint "$project_dir" > "$fingerprint_file"
+
+  if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    env_file_upsert_source "$CLAUDE_ENV_FILE" "$runtime_file"
+    hook_log "Wired ${runtime_file} into CLAUDE_ENV_FILE (static snapshot, not a live shell hook)"
+  fi
+
+  local direnv_ver
+  direnv_ver="$("$direnv_bin" --version 2>/dev/null || echo "unknown")"
+  hook_log "direnv v${direnv_ver} available at ${direnv_bin}"
+}
+
+# --- Execute ---
+
+tool_run_install do_setup
+hook_log_cleanup
+hook_respond

--- a/plugins/direnv/hooks/scripts/install-direnv.sh
+++ b/plugins/direnv/hooks/scripts/install-direnv.sh
@@ -22,6 +22,14 @@
 # and again only when the PreToolUse hook (direnv-check.sh) detects the
 # .envrc fingerprint has changed. See lib/direnv-export.sh for the shared
 # implementation and further rationale.
+#
+# Install mechanism: prefers claude-utils' `agent-plugin ensure-dependency`
+# (mise-based) when `agent-plugin` is on PATH, falling back to a direct
+# GitHub-release download otherwise. Logging: prefers `agent-plugin log-*`
+# when present, always also uses this repo's shared-lib hook-logging.sh
+# lifecycle (hook_log_step/hook_fail/hook_respond). See lib/direnv-export.sh
+# for why both are treated as present-if-available rather than hard
+# dependencies.
 set -euo pipefail
 
 PLUGIN_NAME="direnv"
@@ -75,7 +83,7 @@ source "${CLAUDE_PLUGIN_ROOT}/lib/direnv-export.sh"
 
 # --- Guards ---
 
-plugin_is_enabled || { hook_log "plugin disabled, skipping"; hook_respond; exit 0; }
+plugin_is_enabled || { direnv_log "info" "plugin disabled, skipping"; hook_respond; exit 0; }
 
 # --- Read config ---
 
@@ -93,26 +101,50 @@ resolve_direnv_bin() {
 
   if [ "$auto_install" != "true" ]; then
     if tool_is_available direnv; then
-      hook_log "autoInstall=false, using direnv from PATH at $(command -v direnv)"
+      direnv_log "info" "autoInstall=false, using direnv from PATH at $(command -v direnv)"
       command -v direnv
       return 0
     fi
-    hook_log "autoInstall=false and direnv not on PATH, skipping"
+    direnv_log "info" "autoInstall=false and direnv not on PATH, skipping"
     return 1
   fi
 
   if [ -x "$direnv_bin" ]; then
-    hook_log "direnv already installed at $direnv_bin"
+    direnv_log "info" "direnv already installed at $direnv_bin"
     echo "$direnv_bin"
     return 0
   fi
 
   if tool_is_available direnv; then
     direnv_bin="$(command -v direnv)"
-    hook_log "direnv found on PATH at $direnv_bin"
+    direnv_log "info" "direnv found on PATH at $direnv_bin"
     echo "$direnv_bin"
     return 0
   fi
+
+  # --- Preferred path: claude-utils' agent-plugin, if present ---
+  #
+  # Enhancement, not a hard dependency (see lib/direnv-export.sh header for
+  # why): tries `agent-plugin ensure-dependency direnv "direnv@latest"`
+  # (installs via `mise use -g`) when `agent-plugin` is on PATH. Falls
+  # through to the direct GitHub-release download below on ANY failure —
+  # agent-plugin not installed, its own autoInstall setting declining, no
+  # mise, or the mise install itself failing — so this plugin keeps working
+  # exactly as before for the 100% of users who haven't installed
+  # claude-utils or configured .claude/settings.direnv.yaml.
+  if [ -n "$(direnv_agent_plugin_bin)" ]; then
+    local via_agent_plugin
+    if via_agent_plugin="$(direnv_try_ensure_dependency_via_agent_plugin)" && [ -n "$via_agent_plugin" ]; then
+      direnv_log "info" "direnv resolved via agent-plugin/mise at ${via_agent_plugin}"
+      echo "$via_agent_plugin"
+      return 0
+    fi
+    direnv_log "info" "agent-plugin present but did not provide direnv (declined, no mise, or install failed) — falling back to direct download"
+  fi
+
+  # --- Fallback: direct GitHub release download (unchanged from before the
+  # agent-plugin integration; this is the only path when claude-utils isn't
+  # installed, which is every session today) ---
 
   direnv_detect_platform || return 1
 
@@ -130,7 +162,7 @@ resolve_direnv_bin() {
   hook_log_step "download-direnv" "Downloading direnv v${target_version} from ${url}"
   if curl -fsSL "$url" -o "$direnv_bin" 2>/dev/null; then
     chmod +x "$direnv_bin"
-    hook_log "direnv v${target_version} installed to ${direnv_bin}"
+    direnv_log "info" "direnv v${target_version} installed to ${direnv_bin}"
     echo "$direnv_bin"
     return 0
   fi
@@ -147,7 +179,7 @@ resolve_direnv_bin() {
 # step below silently produces nothing for a fresh/unapproved .envrc.
 auto_allow_envrc() {
   local direnv_bin="$1"
-  [ "$auto_allow" = "true" ] || { hook_log "autoAllow=false, skipping direnv allow"; return 0; }
+  [ "$auto_allow" = "true" ] || { direnv_log "info" "autoAllow=false, skipping direnv allow"; return 0; }
 
   local project_dir
   project_dir="$(cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null && pwd)" || project_dir="${CLAUDE_PROJECT_DIR:-.}"
@@ -162,7 +194,7 @@ auto_allow_envrc() {
   if command -v git &>/dev/null; then
     while IFS= read -r worktree_dir; do
       if [ "$worktree_dir" != "$project_dir" ] && [ -f "${worktree_dir}/.envrc" ]; then
-        hook_log "Allowing worktree ${worktree_dir}/.envrc"
+        direnv_log "info" "Allowing worktree ${worktree_dir}/.envrc"
         "$direnv_bin" allow "${worktree_dir}/.envrc" || true
         allowed_any=true
       fi
@@ -170,7 +202,7 @@ auto_allow_envrc() {
   fi
 
   if [ "$allowed_any" = "false" ]; then
-    hook_log "No .envrc found to allow (looked in ${project_dir})"
+    direnv_log "info" "No .envrc found to allow (looked in ${project_dir})"
   fi
 }
 
@@ -194,12 +226,12 @@ do_setup() {
 
   if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
     env_file_upsert_source "$CLAUDE_ENV_FILE" "$runtime_file"
-    hook_log "Wired ${runtime_file} into CLAUDE_ENV_FILE (static snapshot, not a live shell hook)"
+    direnv_log "info" "Wired ${runtime_file} into CLAUDE_ENV_FILE (static snapshot, not a live shell hook)"
   fi
 
   local direnv_ver
   direnv_ver="$("$direnv_bin" --version 2>/dev/null || echo "unknown")"
-  hook_log "direnv v${direnv_ver} available at ${direnv_bin}"
+  direnv_log "info" "direnv v${direnv_ver} available at ${direnv_bin}"
 }
 
 # --- Execute ---

--- a/plugins/direnv/lib/direnv-export.sh
+++ b/plugins/direnv/lib/direnv-export.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# direnv-export.sh — Shared helpers for the direnv plugin
+#
+# Provides the logic that both the SessionStart hook (install-direnv.sh) and
+# the PreToolUse hook (direnv-check.sh) need: computing a cheap fingerprint
+# of the nearest .envrc, and (re-)running `direnv export bash` to produce a
+# STATIC runtime env file.
+#
+# IMPORTANT — why this is static, not a live eval:
+# `direnv export bash` is invoked here exactly once per call to
+# direnv_export_and_write(). Its output (plain `export FOO=bar` / `unset BAZ`
+# statements) is captured and written verbatim to a runtime file. We do NOT
+# wrap it in `eval "$(direnv export bash)"` inside CLAUDE_ENV_FILE, which
+# would re-invoke the direnv binary on every single Bash tool call. Instead,
+# CLAUDE_ENV_FILE gets one `source <runtime file>` line (added once, idempotently),
+# and the runtime file's *contents* are only regenerated when the PreToolUse
+# hook (direnv-check.sh) detects the .envrc fingerprint changed. This mirrors
+# github-app's env-file.sh pattern (rewrite the runtime file, source it once)
+# rather than mise's `eval "$(mise env -s bash)"` pattern (recompute every call).
+#
+# Requires: hook-logging.sh must be sourced first (for hook_log).
+# Note: Plugins symlink this file into their own lib/ directory is NOT used
+# here — this file lives directly in plugins/direnv/lib/ since it is not
+# shared across plugins.
+
+if [ "${_DIRENV_EXPORT_LOADED:-}" = "true" ]; then
+  return 0 2>/dev/null || true
+fi
+_DIRENV_EXPORT_LOADED="true"
+
+# direnv_detect_platform
+#
+# Sets DIRENV_OS / DIRENV_ARCH globals matching direnv's release asset
+# naming: direnv.<os>-<arch> (e.g. direnv.linux-amd64, direnv.darwin-arm64).
+# Verified against https://github.com/direnv/direnv/releases (v2.37.1).
+# Returns 1 on unsupported platform (after calling hook_fail).
+direnv_detect_platform() {
+  local os arch
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+
+  case "$arch" in
+    x86_64) arch="amd64" ;;
+    aarch64 | arm64) arch="arm64" ;;
+    i386 | i686) arch="386" ;;
+    armv*) arch="arm" ;;
+    *)
+      hook_fail "platform detection" "Unsupported architecture: $arch" \
+        "This plugin supports amd64, arm64, arm, and 386 architectures"
+      return 1
+      ;;
+  esac
+
+  case "$os" in
+    linux | darwin | freebsd | netbsd | openbsd) ;;
+    *)
+      hook_fail "platform detection" "Unsupported OS: $os" \
+        "direnv publishes releases for linux, darwin, freebsd, netbsd, and openbsd"
+      return 1
+      ;;
+  esac
+
+  DIRENV_OS="$os"
+  DIRENV_ARCH="$arch"
+}
+
+# direnv_find_nearest_envrc DIR
+#
+# Walks upward from DIR looking for the nearest .envrc, mirroring direnv's
+# own directory-traversal behavior. Stops at filesystem root or after 64
+# levels (safety bound). Prints the found path via stdout, or nothing if
+# none is found.
+direnv_find_nearest_envrc() {
+  local dir="$1"
+  local i=0
+  dir="$(cd "$dir" 2>/dev/null && pwd)" || return 0
+
+  while [ "$i" -lt 64 ]; do
+    if [ -f "$dir/.envrc" ]; then
+      echo "$dir/.envrc"
+      return 0
+    fi
+    [ "$dir" = "/" ] && return 0
+    dir="$(dirname "$dir")"
+    i=$((i + 1))
+  done
+}
+
+# direnv_fingerprint DIR
+#
+# Computes a cheap fingerprint for the nearest .envrc to DIR: the resolved
+# path plus mtime and size. Two fingerprints differ whenever the file is
+# added, removed, moved to a different ancestor, or modified. Prints the
+# fingerprint via stdout (empty string if no .envrc found anywhere above DIR).
+direnv_fingerprint() {
+  local dir="$1"
+  local envrc
+  envrc="$(direnv_find_nearest_envrc "$dir")"
+
+  if [ -z "$envrc" ]; then
+    echo "none"
+    return 0
+  fi
+
+  local stat_out
+  if stat_out="$(stat -f '%m:%z' "$envrc" 2>/dev/null)"; then
+    : # BSD/macOS stat
+  elif stat_out="$(stat -c '%Y:%s' "$envrc" 2>/dev/null)"; then
+    : # GNU/Linux stat
+  else
+    stat_out="unknown"
+  fi
+
+  echo "${envrc}:${stat_out}"
+}
+
+# direnv_export_and_write DIRENV_BIN TARGET_DIR RUNTIME_FILE
+#
+# Runs `direnv export bash` from TARGET_DIR and overwrites RUNTIME_FILE with
+# the (static) resulting export/unset statements. Always overwrites (never
+# appends) so vars removed from .envrc are correctly dropped on the next
+# regeneration. Safe to call even when there is no .envrc — direnv exits 0
+# with empty output in that case, leaving RUNTIME_FILE with just the header.
+#
+# Args:
+#   $1 — path to the direnv binary
+#   $2 — directory to export from (cwd for the `direnv export` call)
+#   $3 — path to the runtime env file to (re)write
+direnv_export_and_write() {
+  local direnv_bin="$1" target_dir="$2" runtime_file="$3"
+  local export_output=""
+  local rc=0
+
+  mkdir -p "$(dirname "$runtime_file")"
+
+  export_output="$(cd "$target_dir" 2>/dev/null && "$direnv_bin" export bash 2>/dev/null)" || rc=$?
+  # direnv exits non-zero when .envrc is blocked/not-allowed/absent in some
+  # versions; treat that as "nothing to export" rather than a hard failure —
+  # the SessionStart autoAllow step (or the user) is responsible for trust.
+  if [ "$rc" -ne 0 ]; then
+    export_output=""
+  fi
+
+  {
+    echo "# Auto-generated by direnv plugin — do not edit manually."
+    echo "# Regenerated whenever the .envrc fingerprint changes (see direnv-check.sh)."
+    echo "# This is a STATIC snapshot of \`direnv export bash\` output — it is not"
+    echo "# re-evaluated on every command. See lib/direnv-export.sh for rationale."
+    if [ -n "$export_output" ]; then
+      echo "$export_output"
+    else
+      echo "# (no .envrc found, or .envrc not yet allowed — nothing exported)"
+    fi
+  } > "$runtime_file"
+
+  chmod 600 "$runtime_file"
+}

--- a/plugins/direnv/lib/direnv-export.sh
+++ b/plugins/direnv/lib/direnv-export.sh
@@ -22,11 +22,116 @@
 # Note: Plugins symlink this file into their own lib/ directory is NOT used
 # here — this file lives directly in plugins/direnv/lib/ since it is not
 # shared across plugins.
+#
+# --- claude-utils agent-plugin / agent-hook integration (enhancement-if-present) ---
+#
+# nsheaps/claude-utils ships two native binaries meant for exactly this kind
+# of plugin (see that repo's README, "For plugin and hook authors"):
+#   agent-plugin — leveled logging + per-plugin settings + `ensure-dependency`
+#   agent-hook   — parses a hook's JSON stdin into shell vars, emits decisions
+# Installed via `brew install nsheaps/devsetup/claude-utils`.
+#
+# No other ai-mktpl plugin depends on these yet (mise/github-app/1pass predate
+# them and use this repo's own shared-lib bash convention), and their settings
+# story is genuinely different: agent-plugin reads a per-plugin autoInstall
+# flag from `.claude/settings.direnv.yaml`, NOT ai-mktpl's own
+# `plugins.settings.yaml` (read via shared-lib's plugin-config-read.sh) that
+# this plugin's `direnv.settings.yaml` documents and every other ai-mktpl
+# plugin's settings live in. Requiring users to configure autoInstall twice,
+# in two different files, to get auto-install working would be a regression.
+#
+# So this plugin treats agent-plugin/agent-hook as an ENHANCEMENT, not a hard
+# dependency: used opportunistically when on PATH, with ai-mktpl's own
+# shared-lib-based logic remaining the source of truth and the fallback in
+# every case. See install-direnv.sh and direnv-check.sh for where each is
+# used.
 
 if [ "${_DIRENV_EXPORT_LOADED:-}" = "true" ]; then
   return 0 2>/dev/null || true
 fi
 _DIRENV_EXPORT_LOADED="true"
+
+# direnv_agent_plugin_bin
+#
+# Prints the path to `agent-plugin` if it's on PATH, empty otherwise.
+direnv_agent_plugin_bin() {
+  command -v agent-plugin 2>/dev/null || true
+}
+
+# direnv_agent_hook_bin
+#
+# Prints the path to `agent-hook` if it's on PATH, empty otherwise.
+direnv_agent_hook_bin() {
+  command -v agent-hook 2>/dev/null || true
+}
+
+# direnv_log LEVEL MESSAGE
+#
+# Logs MESSAGE at LEVEL (trace|debug|info|warn|error). When `agent-plugin` is
+# on PATH, routes through it (`agent-plugin --plugin direnv log-<level>`),
+# which gives level-threshold filtering via $AGENT_PLUGIN_LOG_LEVEL. Always
+# ALSO calls hook_log — hook_log's accumulation into the message file is what
+# SessionStart's hook_respond() surfaces to the user/agent as
+# additionalContext/systemMessage, and PreToolUse's failure diagnostics
+# (hook_fail, log file) depend on it too. hook_log has no level concept, so
+# every message reaches it regardless of LEVEL; agent-plugin is the one that
+# actually filters by threshold.
+direnv_log() {
+  local level="$1" message="$2"
+  local ap_bin
+  ap_bin="$(direnv_agent_plugin_bin)"
+  if [ -n "$ap_bin" ]; then
+    AGENT_PLUGIN_NAME="direnv" "$ap_bin" "log-${level}" "$message" || true
+  fi
+  hook_log "$message"
+}
+
+# direnv_try_ensure_dependency_via_agent_plugin
+#
+# Best-effort attempt to install direnv via `agent-plugin ensure-dependency`
+# (which shells out to `mise use -g direnv@latest` — verified for real: the
+# mise registry maps the bare name `direnv` to `aqua:direnv/direnv`, and
+# `mise use direnv@latest` resolves and installs v2.37.1 successfully, see
+# this PR's description for the transcript).
+#
+# Prints the resolved direnv binary path via stdout and returns 0 on success.
+# Returns 1 (prints nothing) when: agent-plugin isn't on PATH, its OWN
+# `autoInstall` setting (in .claude/settings.direnv.yaml — a DIFFERENT file
+# from this plugin's own direnv.settings.yaml/plugins.settings.yaml) isn't
+# true, the mise install fails, or the binary still isn't resolvable
+# afterward. Callers are expected to fall back to their own install logic in
+# every failure case — see resolve_direnv_bin() in install-direnv.sh.
+direnv_try_ensure_dependency_via_agent_plugin() {
+  local ap_bin
+  ap_bin="$(direnv_agent_plugin_bin)"
+  [ -n "$ap_bin" ] || return 1
+
+  if ! AGENT_PLUGIN_NAME="direnv" "$ap_bin" ensure-dependency direnv "direnv@latest"; then
+    # Declined (claude-utils' own autoInstall setting is unset/false), no
+    # mise, or the mise install itself failed. agent-plugin already logged
+    # the reason to stderr — nothing more to add here.
+    return 1
+  fi
+
+  # ensure-dependency exited 0, meaning direnv is either already present or
+  # was just installed via `mise use -g`. Either way, resolve a concrete
+  # binary path: `mise use -g` updates mise's shim dir, which may not be on
+  # THIS process's PATH yet (ensure-dependency's own doc comment notes this).
+  if command -v direnv >/dev/null 2>&1; then
+    command -v direnv
+    return 0
+  fi
+  if command -v mise >/dev/null 2>&1; then
+    local via_mise
+    via_mise="$(mise which direnv 2>/dev/null || true)"
+    if [ -n "$via_mise" ] && [ -x "$via_mise" ]; then
+      echo "$via_mise"
+      return 0
+    fi
+  fi
+
+  return 1
+}
 
 # direnv_detect_platform
 #

--- a/plugins/direnv/skills/direnv/SKILL.md
+++ b/plugins/direnv/skills/direnv/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: direnv
+description: >
+  Use this skill when the user asks about managing per-directory environment
+  variables with direnv, working with .envrc files, debugging why direnv env
+  vars aren't appearing in a Bash tool call, or manually reproducing what the
+  direnv plugin's SessionStart/PreToolUse hooks do. Also use when encountering
+  "direnv: error .envrc is blocked" or missing project env vars that should
+  come from an .envrc.
+  <example>why isn't DATABASE_URL from .envrc showing up in Bash?</example>
+  <example>the direnv hook didn't run, set up direnv manually</example>
+  <example>I just added a new .envrc, why hasn't it loaded?</example>
+---
+
+# direnv - Per-Directory Environment Loader
+
+[direnv](https://direnv.net) loads environment variables from a project's
+`.envrc` file when you `cd` into it, and unloads them when you leave. This
+skill covers both **normal direnv usage** and **how the `direnv` plugin wires
+it into a Claude Code session** (for manual reproduction when a hook didn't
+run).
+
+## Quick Reference: Normal direnv Usage
+
+### `.envrc` basics
+
+```bash
+# .envrc
+export DATABASE_URL="postgres://localhost/mydb"
+export NODE_ENV="development"
+
+# Load a .env file
+dotenv
+
+# Add to PATH
+PATH_add ./bin
+
+# Use a specific tool version manager stdlib function
+use node 22
+```
+
+### Core commands
+
+| Command                 | Description                                                                                            |
+| ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| `direnv allow [.envrc]` | Trust an `.envrc` so it's allowed to load                                                              |
+| `direnv deny [.envrc]`  | Revoke trust                                                                                           |
+| `direnv reload`         | Force a reload in the current shell (interactive)                                                      |
+| `direnv export bash`    | Print the export/unset diff for the current dir as bash statements (does NOT modify the current shell) |
+| `direnv status`         | Show current direnv state and loaded `.envrc`                                                          |
+| `direnv edit [.envrc]`  | Edit and auto-allow in one step                                                                        |
+
+### Why direnv might not load
+
+1. **Not allowed yet**: a fresh or modified `.envrc` must be explicitly trusted: `direnv allow`
+2. **No shell hook installed**: interactively, direnv requires `eval "$(direnv hook bash)"` in your shell rc file. **This Claude Code plugin intentionally does NOT install that hook** — see below.
+
+## How This Plugin Wires direnv Into a Session
+
+Unlike normal interactive usage, this plugin does not install `direnv hook
+bash`. Instead:
+
+1. `hooks/scripts/install-direnv.sh` (SessionStart) installs direnv if
+   needed, runs `direnv allow` on the project's `.envrc`, then runs
+   `direnv export bash` **once** and writes the output as static
+   `export`/`unset` statements to `$CLAUDE_PLUGIN_DATA/direnv-env`.
+2. That file is sourced (once) from `CLAUDE_ENV_FILE`, so every `Bash` tool
+   call picks it up.
+3. `hooks/scripts/direnv-check.sh` (PreToolUse, matcher `Bash`) checks
+   (debounced) whether the `.envrc` fingerprint changed since the last
+   export, and if so, re-runs `direnv export bash` and rewrites
+   `direnv-env` in place.
+
+See the plugin's `README.md` for the full rationale (avoiding
+eval-injection and per-command stderr/stdout pollution from the ambient
+shell hook).
+
+## Manually Reproducing the Plugin's Setup
+
+If the SessionStart hook did not run (plugin disabled, manual shell,
+teammate started without hooks), reproduce it by hand:
+
+```bash
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA:-$HOME/.claude/plugins/data/direnv-ai-mktpl}"
+mkdir -p "$CLAUDE_PLUGIN_DATA"
+
+# 1. Ensure direnv is installed (or use your own: brew install direnv)
+command -v direnv >/dev/null || echo "install direnv first"
+
+# 2. Allow the .envrc (required before export will produce anything)
+direnv allow "${CLAUDE_PROJECT_DIR:-.}/.envrc"
+
+# 3. Compute the diff once (static — not a live hook)
+(cd "${CLAUDE_PROJECT_DIR:-.}" && direnv export bash) > "$CLAUDE_PLUGIN_DATA/direnv-env"
+
+# 4. Wire it into CLAUDE_ENV_FILE (idempotent — check before appending)
+if [[ -n "${CLAUDE_ENV_FILE:-}" ]] && ! grep -qF "$CLAUDE_PLUGIN_DATA/direnv-env" "$CLAUDE_ENV_FILE" 2>/dev/null; then
+  echo "source \"$CLAUDE_PLUGIN_DATA/direnv-env\"" >> "$CLAUDE_ENV_FILE"
+fi
+
+# In the current shell (outside a fresh Bash tool call), source it directly:
+source "$CLAUDE_PLUGIN_DATA/direnv-env"
+```
+
+## Verify
+
+```bash
+# Confirm the runtime file has content beyond the header comment
+grep -v '^#' "$CLAUDE_PLUGIN_DATA/direnv-env"
+
+# Confirm a fresh Bash call sees the vars (they come from CLAUDE_ENV_FILE)
+echo "${DATABASE_URL:+set}"
+```
+
+## Troubleshooting
+
+| Symptom                                               | Likely cause / fix                                                                                                                                                                                                                                          |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Vars missing even though `.envrc` exists              | Not yet allowed — run `direnv allow`, then re-run the SessionStart hook (or Step 3 above)                                                                                                                                                                   |
+| Vars still stale after editing `.envrc`               | PreToolUse debounce window not yet elapsed (default 2s, `checkIntervalSeconds`), or the edited `.envrc` is not the nearest one to the resolved target directory                                                                                             |
+| New nested `.envrc` (in a subdirectory) not picked up | The `PreToolUse` hook resolves the target directory from a leading `cd` in the Bash command; without one it always checks `$CLAUDE_PROJECT_DIR`'s ancestor chain. Add an explicit `cd <dir> &&` prefix, or manually re-run Step 3 above from that directory |
+| `direnv: error .envrc is blocked`                     | Run `direnv allow <path-to-.envrc>`                                                                                                                                                                                                                         |
+
+## Related
+
+- Plugin source: `hooks/scripts/install-direnv.sh`, `hooks/scripts/direnv-check.sh`, `lib/direnv-export.sh`
+- **[mise](../../mise)** plugin — same "static export, no shell hook" pattern for tool version management


### PR DESCRIPTION
## Summary

Adds a new `direnv` plugin, mirroring the `mise` and `github-app` plugins' structure and conventions.

- **SessionStart hook** (`install-direnv.sh`): resolves a direnv binary, runs `direnv allow` on the project's `.envrc` (and any git worktrees), then computes the `.envrc` diff **once** via `direnv export bash` and writes it as **static** `export`/`unset` statements to a runtime file sourced (once, idempotently) via `CLAUDE_ENV_FILE`.
- **PreToolUse hook** (`direnv-check.sh`, matcher `Bash`): before each Bash call, checks (debounced, default 2s via `checkIntervalSeconds`) whether the nearest `.envrc`'s fingerprint (path + mtime + size) changed, and if so re-runs the export and rewrites the runtime file in place — so vars removed from `.envrc` are correctly dropped, not just left stale.
- Deliberately does **not** install `direnv hook bash` (the `PROMPT_COMMAND`-style shell hook) — same rationale documented at length in `mise`'s `install-mise.sh`: stderr/stdout pollution on every command, eval-injection risk, unnecessary `cd`/`pushd`/`popd` overrides in a non-interactive agent shell.
- Depends on `shared-lib` (`tool-install.sh`, `plugin-config-read.sh`, `hook-logging.sh`, `env-file.sh`) exactly like `mise`/`github-app`/`1pass`.
- Includes `direnv.settings.yaml`, `README.md`, `SPEC.md`, `.release-it.js` (copied verbatim from mise's pattern), and a manual-operation `skills/direnv/SKILL.md`.
- Registered in `.claude-plugin/marketplace.json` (alphabetical position; CD bumps versions on merge per this repo's `versioning.md`).

## On "claude-utils agent-plugin helpers"

**Correction from an earlier version of this PR description:** I initially reported that no such thing existed in `nsheaps/claude-utils`, based on investigating a local checkout that turned out to be stale. That was wrong. `packages/agent-plugin/` and `packages/agent-hook/` are real, documented in that repo's README ("For plugin and hook authors"), and this PR now integrates with both:

- **`agent-plugin`** — `agent-plugin ensure-dependency <cli> <mise-package>` installs a missing CLI via `mise use -g <mise-package>`, gated on that plugin's own `autoInstall` setting (read from `.claude/settings.<plugin>.yaml`, defaulting to `false`). Also provides leveled logging (`agent-plugin log-info`/`log-warn`/etc, threshold via `$AGENT_PLUGIN_LOG_LEVEL`) and per-plugin settings read/write.
- **`agent-hook`** — `agent-hook export-input` parses a hook's JSON stdin into shell exports (`HOOK_TOOL_NAME`, `HOOK_TOOL_INPUT_COMMAND`, etc.) via `eval`, replacing hand-rolled `jq` parsing. Also provides `allow`/`deny`/`halt`/`warn-user`/`post` for emitting a hook's JSON decision.

**How I verified this for real** (not just reading source): built both binaries from a clean `origin/main` checkout in an isolated worktree (`bun install && bun run build`), confirmed `mise use direnv@latest` resolves through the registry's `aqua:direnv/direnv` backend and installs direnv v2.37.1, then ran `install-direnv.sh` and `direnv-check.sh` end-to-end in scratch project directories with the built binaries on `PATH` (and separately with them absent) to exercise every branch — see "Test plan" below.

**Where I landed: enhancement-if-present, not a hard dependency.** `agent-plugin`'s settings file (`.claude/settings.direnv.yaml`) is a *different* file from this plugin's own `direnv.settings.yaml`/`plugins.settings.yaml` convention (the one `shared-lib`'s `plugin-config-read.sh` reads, and what every other ai-mktpl plugin uses). Requiring both to be configured to get auto-install working would be a real regression, and no other ai-mktpl plugin (`mise`, `github-app`, `1pass`) depends on claude-utils yet — brew's `claude-utils` formula on this machine is still 0.10.0 and doesn't even ship these binaries. So:

- `direnv.settings.yaml`'s `autoInstall` stays the single source of truth for *whether* to install at all.
- `install-direnv.sh` tries `agent-plugin ensure-dependency direnv "direnv@latest"` first when `agent-plugin` is on PATH, and falls back to the direct GitHub-release download on **any** failure (agent-plugin absent, its own autoInstall declined, no mise, or the mise install failing) — zero behavior change for the 100% of users who don't have claude-utils installed today.
- Logging routes through `agent-plugin log-*` when present, always *also* through this repo's `hook-logging.sh` lifecycle (SessionStart's summary output and failure diagnostics depend on it regardless).
- `direnv-check.sh` uses `agent-hook export-input` when present, falling back to `jq`. It never calls `agent-hook allow`/`deny` for the "nothing changed" case — per this repo's own `hook-output-patterns.md`, a PreToolUse hook with no opinion must emit **nothing**, not an explicit `allow` (which would bypass the permission system for every Bash call). That rule takes precedence over reaching for every agent-hook feature just because it exists.
- The debounce/throttle placeholder now links to the confirmed in-flight [`nsheaps/claude-utils#436`](https://github.com/nsheaps/claude-utils/pull/436) (branch `feature/agent-hook-throttle`), which generalizes this exact pattern into a reusable, sourceable helper. Swapping to it once merged is a one-function change (`should_check`/`record_check` are isolated for exactly this).

Full rationale (with more detail than fits here) is in the plugin's `README.md` under "claude-utils integration".

## Test plan

- [x] `plugin.json`/`hooks.json`/`marketplace.json` JSON syntax and `direnv.settings.yaml` YAML syntax validated
- [x] `claude plugin validate plugins/direnv/.claude-plugin/plugin.json` — passes
- [x] `mise run validate-marketplace` — passes
- [x] `shellcheck` on all scripts — only info-level `SC1091`/`SC2317`/`SC2034` findings, matching the same class of findings shellcheck reports on existing plugins (e.g. `mise`'s install script)
- [x] `prettier --check` on all files — passes
- [x] `install-direnv.sh` end-to-end in a scratch project dir with a real `.envrc`, **without** claude-utils on PATH — confirmed the (unchanged) direct-download install path, `direnv-env` runtime file, and `CLAUDE_ENV_FILE` wiring are correct
- [x] `install-direnv.sh` end-to-end **with** locally-built `agent-plugin`/`agent-hook` on PATH and direnv deliberately kept off PATH (isolated `MISE_DATA_DIR`/`MISE_CONFIG_DIR` so nothing touched this machine's real mise state) — confirmed `agent-plugin ensure-dependency` installs direnv via `mise use -g direnv@latest` for real, resolves the binary via `mise which` when it isn't yet on the current process's `PATH`, and wires it into `CLAUDE_ENV_FILE` correctly
- [x] Also exercised the fallback: forced `agent-plugin`'s own `ensure-dependency` to fail (untrusted mise config in the ambient directory) and confirmed `install-direnv.sh` correctly fell through to the direct GitHub-release download rather than aborting
- [x] `direnv-check.sh` — confirmed: (a) no-op when nothing changed (silent, exit 0, no stdout), (b) re-exports and correctly *drops* a var removed from `.envrc` (overwrite, not append), (c) debounce window actually throttles a same-second re-check, (d) `cd subdir &&` prefix parsing correctly resolves a nested `.envrc`, (e) with `agent-hook` on PATH, `agent-hook export-input` correctly parses `HOOK_TOOL_NAME`/`HOOK_TOOL_INPUT_COMMAND` and drives the same directory-resolution and re-export logic, (f) with `agent-hook` absent, the `jq` fallback still works identically
- [ ] Not tested: CI's full `mise run check`/`mise run validate` pipeline (local `mise run setup` hit an unrelated `aqua:cli/cli` attestation/network failure installing this repo's own dev toolchain — pre-existing, unrelated to this change)
- [ ] Not tested: a live Claude Code session invoking these hooks through the real harness (SessionStart/PreToolUse wiring), since I don't have access to spin one up standalone
- [ ] Not tested against a real Homebrew-installed `claude-utils` build of `agent-plugin`/`agent-hook` — the current brew formula (0.10.0) predates these binaries, so verification used binaries built directly from `origin/main` of that repo in an isolated worktree


Co-Authored-By: Claude Code (User Settings, in: /Users/nathan.heaps/src/nsheaps/ai-mktpl) <noreply@anthropic.com>

https://claude.ai/code/session_01GdW3bEd5bo54U5eKm3njWe
