### PR TITLE
Document re-apply-label loop for AI review re-requests

### DIFF
--- a/.claude/rules/auto-pr-management.md
+++ b/.claude/rules/auto-pr-management.md
@@ -54,8 +54,11 @@ Before creating, check if a PR already exists for the current branch. If one exi
 
 1. **Create as draft** — all new PRs start as drafts
 2. **Add `request-review` label** — triggers AI code review automatically
-3. **Address review feedback** — fix any issues found by the AI review
-4. **Mark ready** when work is complete and CI passes
+3. **Address review feedback** — fix any issues found by the AI review (push a fix, or reply in the thread justifying why you're not changing something)
+4. **Re-apply `request-review`** to request another review round — the receiver clears the label itself the moment a review starts, so a label sitting on the PR always means "not yet reviewed." Iterate steps 3-4 until the review agent approves.
+5. **Gate before human engagement**: only once CI is green, the PR is mergeable (no conflicts), AND the review agent has approved, reach out to the user/handler for their own review — while keeping the PR in draft.
+
+Do not remove-then-re-add the label after every ordinary push just to force a re-trigger — that was only needed before the receiver auto-cleared the label at review start. Re-apply it specifically when requesting a new review round.
 
 ## See Also
 

--- a/.claude/rules/auto-pr-management.md
+++ b/.claude/rules/auto-pr-management.md
@@ -55,10 +55,10 @@ Before creating, check if a PR already exists for the current branch. If one exi
 1. **Create as draft** — all new PRs start as drafts
 2. **Add `request-review` label** — triggers AI code review automatically
 3. **Address review feedback** — fix any issues found by the AI review (push a fix, or reply in the thread justifying why you're not changing something)
-4. **Re-apply `request-review`** to request another review round — the receiver clears the label itself the moment a review starts, so a label sitting on the PR always means "not yet reviewed." Iterate steps 3-4 until the review agent approves.
+4. **Re-apply `request-review`** to request another review round — this repo's review workflow clears the label itself the moment a review starts (`.github/workflows/claude-code-review.yaml`), so a label sitting on the PR always means "not yet reviewed." Iterate steps 3-4 until the review agent approves.
 5. **Gate before human engagement**: only once CI is green, the PR is mergeable (no conflicts), AND the review agent has approved, reach out to the user/handler for their own review — while keeping the PR in draft.
 
-Do not remove-then-re-add the label after every ordinary push just to force a re-trigger — that was only needed before the receiver auto-cleared the label at review start. Re-apply it (add it back if the receiver has cleared it, or remove + re-add if it's somehow still on) specifically when you're requesting a new review round after addressing feedback.
+Do not remove-then-re-add the label after every ordinary push just to force a re-trigger — that was only needed before the review workflow auto-cleared the label at review start. Re-apply it (add it back if the review workflow has cleared it, or remove + re-add if it's somehow still on) specifically when you're requesting a new review round after addressing feedback.
 
 ## See Also
 

--- a/.claude/rules/auto-pr-management.md
+++ b/.claude/rules/auto-pr-management.md
@@ -58,7 +58,7 @@ Before creating, check if a PR already exists for the current branch. If one exi
 4. **Re-apply `request-review`** to request another review round — the receiver clears the label itself the moment a review starts, so a label sitting on the PR always means "not yet reviewed." Iterate steps 3-4 until the review agent approves.
 5. **Gate before human engagement**: only once CI is green, the PR is mergeable (no conflicts), AND the review agent has approved, reach out to the user/handler for their own review — while keeping the PR in draft.
 
-Do not remove-then-re-add the label after every ordinary push just to force a re-trigger — that was only needed before the receiver auto-cleared the label at review start. Re-apply it specifically when requesting a new review round.
+Do not remove-then-re-add the label after every ordinary push just to force a re-trigger — that was only needed before the receiver auto-cleared the label at review start. Re-apply it (add it back if the receiver has cleared it, or remove + re-add if it's somehow still on) specifically when you're requesting a new review round after addressing feedback.
 
 ## See Also
 

--- a/plugins/common-sense/rules/critical-system-instructions.md
+++ b/plugins/common-sense/rules/critical-system-instructions.md
@@ -38,7 +38,7 @@
 
      **After every push, re-arm the monitor. Re-firing depends on PR draft state:**
      - **Non-draft PR**: push (`synchronize` event) re-fires the workflow naturally. No label dance needed.
-     - **Draft PR** (the default per `auto-pr-management.md`): push does **NOT** re-fire the workflow — `synchronize` is gated out by the workflow's `if:` condition (`pull_request.draft != true`). You MUST remove + re-add the `request-review` label IMMEDIATELY after every push to a draft to force a re-fire. Do not wait the 6-minute SKIPPED-detection window — for drafts, push-without-re-label is a known certainty, not an uncertain probe.
+     - **Draft PR** (the default per `auto-pr-management.md`): push does **NOT** re-fire the workflow — `synchronize` is gated out by the workflow's `if:` condition (`pull_request.draft != true`). Re-apply the `request-review` label (remove + re-add) to force a re-fire, but only when you actually want a fresh review round — i.e. after addressing the previous review's feedback, not after every unrelated commit. See `pr-management.md` §"Requesting a Fresh AI Review".
 
   6. Once that state is achieved, use your best judgement to determine if the PR should be merged, and follow up actions to take (eg wait for homebrew tap to publish, bump versions in mise.toml, install new versions of tools and plugins, restart agents/services). If the PR is reviewed, but the review requirement isn't satisfied, you MUST tag Nate (your handler) in discord.
   7. After the PR merges, coordinate with the PM agent (Henry) to update linked tickets and close any bugs the change resolves:

--- a/plugins/common-sense/rules/pr-management.md
+++ b/plugins/common-sense/rules/pr-management.md
@@ -17,3 +17,15 @@ You are expected to open and maintain PRs. Follow these rules:
 3. **Keep PRs up to date**: Update the PR title, body, and labels as the branch evolves.
 4. **Close duplicates**: If one PR duplicates functionality from another or resolves an issue, use GitHub magic phrases (e.g., `Closes #123`, `Fixes #456`) in the PR body to link and close appropriately.
 5. **Never mark ready for review**: Do NOT remove the draft status from a PR. Only the user may do that.
+
+## Requesting a Fresh AI Review (`request-review` label)
+
+The `request-review` label is what forces a review on a still-draft PR (non-draft PRs get reviewed automatically on every push). The review receiver removes the label itself the instant a review actually starts — so a label sitting on the PR always means "a review hasn't started yet," never a stale leftover from an earlier round. That makes **re-applying the label** the correct way to ask for another look:
+
+1. Address the AI review's feedback — either push a fix, or reply in the review thread explaining why you're not changing something (a justification is a valid response, not just a code change).
+2. Re-apply the `request-review` label (remove + re-add, or just add if it's already gone) to request a fresh review round.
+3. Repeat until the review agent approves.
+
+**Do not remove-then-re-add the label after every ordinary push just to force a re-trigger.** That workaround was needed when the label used to sit "on" indefinitely after firing once on a draft PR; it no longer is, since the receiver clears it at review-start. Re-apply the label specifically when you want a new review round — after addressing feedback, not after every unrelated commit.
+
+**Gate before engaging the user:** only once (a) CI is green, (b) the PR is mergeable with no conflicts, AND (c) the review agent has approved, should you — while keeping the PR in draft — reach out to the user/handler for their own review.

--- a/plugins/common-sense/rules/pr-management.md
+++ b/plugins/common-sense/rules/pr-management.md
@@ -26,6 +26,6 @@ The `request-review` label is what forces a review on a still-draft PR (non-draf
 2. Re-apply the `request-review` label (remove + re-add, or just add if it's already gone) to request a fresh review round.
 3. Repeat until the review agent approves.
 
-**Do not remove-then-re-add the label after every ordinary push just to force a re-trigger.** That workaround was needed when the label used to sit "on" indefinitely after firing once on a draft PR; it no longer is, since the receiver clears it at review-start. Re-apply the label specifically when you want a new review round — after addressing feedback, not after every unrelated commit.
+**Do not remove-then-re-add the label after every ordinary push just to force a re-trigger.** That workaround was needed when the label used to sit "on" indefinitely after firing once on a draft PR. Where the receiver clears it at review-start, it no longer is; where it doesn't, remove and re-add rather than assuming a present label is still doing something. Re-apply the label specifically when you want a new review round — after addressing feedback, not after every unrelated commit.
 
 **Gate before engaging the user:** only once (a) CI is green, (b) the PR is mergeable with no conflicts, AND (c) the review agent has approved, should you — while keeping the PR in draft — reach out to the user/handler for their own review.

--- a/plugins/common-sense/rules/pr-management.md
+++ b/plugins/common-sense/rules/pr-management.md
@@ -20,7 +20,7 @@ You are expected to open and maintain PRs. Follow these rules:
 
 ## Requesting a Fresh AI Review (`request-review` label)
 
-The `request-review` label is what forces a review on a still-draft PR (non-draft PRs get reviewed automatically on every push). The review receiver removes the label itself the instant a review actually starts — so a label sitting on the PR always means "a review hasn't started yet," never a stale leftover from an earlier round. That makes **re-applying the label** the correct way to ask for another look:
+The `request-review` label is what forces a review on a still-draft PR (non-draft PRs get reviewed automatically on every push). Where the review workflow clears the label at review-start (ai-mktpl does — see the `Remove request-review label` step in `.github/workflows/claude-code-review.yaml`), a label sitting on the PR means "a review hasn't started yet" rather than a stale leftover; where it doesn't, the label may simply be left over from an earlier round. Either way, **re-applying the label** is the correct way to ask for another look:
 
 1. Address the AI review's feedback — either push a fix, or reply in the review thread explaining why you're not changing something (a justification is a valid response, not just a code change).
 2. Re-apply the `request-review` label (remove + re-add, or just add if it's already gone) to request a fresh review round.

--- a/plugins/common-sense/rules/pr-workflow.md
+++ b/plugins/common-sense/rules/pr-workflow.md
@@ -64,16 +64,16 @@ EOF
 
 If the PR is still in draft, apply the `request-review` label to force a review — non-draft PRs get reviewed automatically on every push. The review receiver removes the label the moment a review starts, so a label sitting on the PR always means "not yet reviewed." To request another round after addressing feedback (a pushed fix, or just a reply justifying why you didn't change something), re-apply the label. See `pr-management.md`'s "Requesting a Fresh AI Review" section for the full loop and the CI-green/mergeable/approved gate that must hold before engaging the user.
 
-## When to Move from Draft
+## When a PR Is Ready to Leave Draft
 
-Move PR from draft to ready when:
+**Only the user/handler moves a PR out of draft** — see `pr-management.md` rule 5. Never run `gh pr ready` on an agent-authored PR. The criteria below are what makes a PR *ready for that decision*, so drive toward them and then hand off:
 
 - All planned work is complete
 - Tests pass
 - You've self-reviewed the changes
-- Ready for actual review
+- The AI review agent has approved (see "Requesting a Fresh AI Review" above)
 
-**Note:** Per `pr-management.md`, AI-created PRs stay in draft — only the user/handler moves a PR out of draft. `gh pr ready` below is documented for completeness but should not be run unilaterally on agent-authored PRs.
+For reference, the command the user runs is:
 
 ```bash
 gh pr ready <number>

--- a/plugins/common-sense/rules/pr-workflow.md
+++ b/plugins/common-sense/rules/pr-workflow.md
@@ -60,6 +60,10 @@ EOF
 - Git history becomes unclear when PRs touch unrelated code
 - Rollbacks are harder when changes are mixed
 
+## Requesting a Fresh AI Review
+
+If the PR is still in draft, apply the `request-review` label to force a review — non-draft PRs get reviewed automatically on every push. The review receiver removes the label the moment a review starts, so a label sitting on the PR always means "not yet reviewed." To request another round after addressing feedback (a pushed fix, or just a reply justifying why you didn't change something), re-apply the label. See `pr-management.md`'s "Requesting a Fresh AI Review" section for the full loop and the CI-green/mergeable/approved gate that must hold before engaging the user.
+
 ## When to Move from Draft
 
 Move PR from draft to ready when:
@@ -68,6 +72,8 @@ Move PR from draft to ready when:
 - Tests pass
 - You've self-reviewed the changes
 - Ready for actual review
+
+**Note:** Per `pr-management.md`, AI-created PRs stay in draft — only the user/handler moves a PR out of draft. `gh pr ready` below is documented for completeness but should not be run unilaterally on agent-authored PRs.
 
 ```bash
 gh pr ready <number>

--- a/plugins/common-sense/rules/pr-workflow.md
+++ b/plugins/common-sense/rules/pr-workflow.md
@@ -62,7 +62,7 @@ EOF
 
 ## Requesting a Fresh AI Review
 
-If the PR is still in draft, apply the `request-review` label to force a review — non-draft PRs get reviewed automatically on every push. The review receiver removes the label the moment a review starts, so a label sitting on the PR always means "not yet reviewed." To request another round after addressing feedback (a pushed fix, or just a reply justifying why you didn't change something), re-apply the label. See `pr-management.md`'s "Requesting a Fresh AI Review" section for the full loop and the CI-green/mergeable/approved gate that must hold before engaging the user.
+If the PR is still in draft, apply the `request-review` label to force a review — non-draft PRs get reviewed automatically on every push. Where the review workflow clears the label at review-start (ai-mktpl does), a label sitting on the PR means "not yet reviewed" rather than a leftover from an earlier round; where it doesn't, remove and re-add rather than assuming a present label is still doing something. To request another round after addressing feedback (a pushed fix, or just a reply justifying why you didn't change something), re-apply the label. See `pr-management.md`'s "Requesting a Fresh AI Review" section for the full loop and the CI-green/mergeable/approved gate that must hold before engaging the user.
 
 ## When a PR Is Ready to Leave Draft
 

--- a/plugins/common-sense/rules/pr-workflow.md
+++ b/plugins/common-sense/rules/pr-workflow.md
@@ -66,7 +66,7 @@ If the PR is still in draft, apply the `request-review` label to force a review 
 
 ## When a PR Is Ready to Leave Draft
 
-**Only the user/handler moves a PR out of draft** — see `pr-management.md` rule 5. Never run `gh pr ready` on an agent-authored PR. The criteria below are what makes a PR *ready for that decision*, so drive toward them and then hand off:
+**Only the user/handler moves a PR out of draft** — see `pr-management.md` rule 5. Never run `gh pr ready` on an agent-authored PR. The criteria below are what makes a PR _ready for that decision_, so drive toward them and then hand off:
 
 - All planned work is complete
 - Tests pass


### PR DESCRIPTION
## Summary

- `nsheaps/agents`'s `review-receiver.yaml` will remove the `request-review` label the moment a review actually starts, once [nsheaps/agents#333](https://github.com/nsheaps/agents/pull/333) merges — freeing it to be re-applied as a "please review again" signal.
- Updates `plugins/common-sense/rules/pr-management.md`, `pr-workflow.md`, `critical-system-instructions.md`, and `.claude/rules/auto-pr-management.md` to describe the loop: after addressing review feedback (push a fix, or reply justifying why not), re-apply the `request-review` label to request a fresh review round; iterate until CI is green, the PR is mergeable (no conflicts), and the review agent has approved; only then, while keeping the PR in draft, engage the user/handler for their own review.
- Removes the old blanket instruction to remove-then-re-add the label after every push to a draft PR — that was only ever needed as a workaround, and `critical-system-instructions.md` now states it as a conditional (do it when you actually want a new review round) rather than a mandate that contradicted the new guidance.

## Test plan

- [x] Docs-only change — no code to test directly
- [ ] Verify against [nsheaps/agents#333](https://github.com/nsheaps/agents/pull/333) once merged, confirming the receiver-side label removal behavior matches what's documented here

Session: https://claude.ai/code/session_01QgxCh7McqCsLvVSrQZE8U5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgxCh7McqCsLvVSrQZE8U5)_