### PR TITLE
fix: add ref key and mise-install hook for github-app

### DIFF
--- a/.claude/hooks/session-start/02-mise-install.sh
+++ b/.claude/hooks/session-start/02-mise-install.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Install mise and mise-managed tools on session start (web/cloud sessions only).
+#
+# Closes a gap identified in the cross-repo consistency audit
+# (nsheaps/.ai-agent-jack docs/research/github-app-cloud-session-consistency-audit-2026-08-12.md):
+# this repo's own environment-setup-and-maintenance.md rule describes this
+# behavior as the intended design, but 01-install-plugins.sh only ever
+# installed Claude Code plugins, not mise tools. Modeled on the one repo
+# that already does this correctly: nsheaps/.github's
+# .claude/hooks/session-start.sh (minus its yarn/corepack-specific steps,
+# which don't apply here).
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+echo "Setting up mise-managed tools..."
+
+if ! command -v mise &>/dev/null; then
+  echo "Installing mise..."
+  curl -fsSL https://mise.run | sh
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# Persist PATH so mise (and the tools it shims, e.g. gh) resolve in later tool calls.
+echo 'export PATH="$HOME/.local/bin:$PATH"' >>"$CLAUDE_ENV_FILE"
+
+cd "$CLAUDE_PROJECT_DIR"
+
+echo "Installing mise tools..."
+mise trust --yes
+mise install --yes
+
+eval "$(mise activate bash)"
+echo 'eval "$(mise activate bash)"' >>"$CLAUDE_ENV_FILE"
+
+echo "mise tool setup complete."

--- a/.claude/plugins.settings.yaml
+++ b/.claude/plugins.settings.yaml
@@ -10,6 +10,7 @@ github:
 github-app:
   enabled: true
   autoGitConfig: true
+  ref: 'op://Agent-Jack/github--app--jack'
 
 mise:
   autoInstallTools: true


### PR DESCRIPTION
## Summary

- Add the missing `ref: "op://Agent-Jack/github--app--jack"` key to `.claude/plugins.settings.yaml`'s `github-app:` block — `enabled`/`autoGitConfig` were already explicit here, but `ref` was missing entirely, so this repo's cloud sessions weren't authenticating with Jack's GitHub App identity.
- Add `.claude/hooks/session-start/02-mise-install.sh` to this repo's existing SessionStart dispatcher (`.claude/hooks/session-start/`), closing a gap this repo's own `environment-setup-and-maintenance.md` rule describes as intended design but was never actually implemented — nothing previously ran `mise install`/`mise activate` or persisted a PATH export for cloud sessions.
- One of six sibling PRs applying the same consistency fixes across every repo authenticating via Agent-Jack's `github-app` credential (`op://Agent-Jack/github--app--jack`): `.ai-agent-jack`, `agents`, `claude-utils`, `nsheaps`, `ai-mktpl`, `.github`. See [nsheaps/.ai-agent-jack#485](https://github.com/nsheaps/.ai-agent-jack/pull/485) for the originating audit.

## Test plan

- [x] Rebased onto latest `origin/main` per this repo's `auto-pr-management.md` convention
- [ ] `mise run validate` / `mise run lint` (CI will confirm)
- [ ] Verify a fresh cloud session picks up `gh` on `PATH` after the SessionStart hook runs

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqVqaxaqzXNLT5qyzXx1KB)_