### PR TITLE
push sentinel

### DIFF
--- a/plugins/hello-world/.claude-plugin/plugin.json
+++ b/plugins/hello-world/.claude-plugin/plugin.json
@@ -1,6 +1,0 @@
-{
-  "name": "hello-world",
-  "description": "Fixture plugin used by this repo's integration tests (bin/plugctl doctor). Not a real capability.",
-  "version": "0.0.0",
-  "author": { "name": "Nathan Heaps" }
-}

--- a/plugins/hello-world/.claude-plugin/plugin.json
+++ b/plugins/hello-world/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "hello-world",
+  "description": "Fixture plugin used by this repo's integration tests (bin/plugctl doctor). Not a real capability.",
+  "version": "0.0.0",
+  "author": { "name": "Nathan Heaps" }
+}

--- a/plugins/plugin-sentinel/.claude-plugin/plugin.json
+++ b/plugins/plugin-sentinel/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "plugin-sentinel",
   "description": "Fixture plugin used by other marketplaces to test connectivity and reference",
   "version": "0.0.1",
-  "author": { 
+  "author": {
     "name": "Nathan Heaps",
     "email": "nsheaps@gmail.com",
     "url": "https://github.com/nsheaps"

--- a/plugins/plugin-sentinel/.claude-plugin/plugin.json
+++ b/plugins/plugin-sentinel/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "plugin-sentinel",
+  "description": "Fixture plugin used by other marketplaces to test connectivity and reference",
+  "version": "0.0.1",
+  "author": { 
+    "name": "Nathan Heaps",
+    "email": "nsheaps@gmail.com",
+    "url": "https://github.com/nsheaps"
+  }
+}

--- a/plugins/plugin-sentinel/README.md
+++ b/plugins/plugin-sentinel/README.md
@@ -1,0 +1,3 @@
+# plugins/plugin-sentinel/
+
+A sample plugin used/useable by external marketplaces to test if they can properly reference external plugins in their marketplace.


### PR DESCRIPTION
This pull request introduces two new fixture plugins intended for integration testing and external connectivity validation, along with relevant documentation. These plugins are not intended for production use but serve as test fixtures for internal and external systems.

**New fixture plugins for testing:**

* Added `plugin.json` for `hello-world` plugin as an internal integration test fixture, including basic metadata.
* Added `plugin.json` for `plugin-sentinel` plugin, designed for external marketplaces to test connectivity and referencing, with extended author metadata.

**Documentation:**

* Added a `README.md` file for `plugin-sentinel` explaining its purpose as a sample plugin for external marketplace testing.