### PR TITLE
Revise license terms for broader applicability

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,151 +1,99 @@
-# License
+Copyright 2026 Nathan Heaps <nsheaps@gmail.com>.
+Internal use granted to
 
-Copyright (c) 2026 Nathan Heaps. All rights reserved.
+# PolyForm Internal Use License 1.0.0
 
-> **About this license.** This is a source-available, internal-use license
-> adapted from real, named standardized licenses rather than written from
-> scratch:
->
-> - Its overall structure and most of its wording come from the
->   [**PolyForm Internal Use License 1.0.0**]
->   (https://polyformproject.org/licenses/internal-use/1.0.0), which is
->   purpose-built for "use the software for internal business operations, do
->   not distribute it." The one substantive adaptation is that PolyForm grants
->   rights to _"you and your company"_ (whoever accepts the license), whereas
->   this license grants them to a **single, specifically named licensee**
->   (Oura, defined below). That is a real difference: the licensor here is not
->   a generic member of the licensee's organization, so the "permitted
->   purpose" is pinned to Oura's internal operations by name rather than to
->   the acceptor's own organization.
-> - The **Patent License** section is modeled on **Apache License 2.0,
->   Section 3 ("Grant of Patent License")**, including its patent-litigation
->   termination.
-> - The **No Trademark License** section is modeled on **Apache License 2.0,
->   Section 6 ("Trademarks")**.
-> - The **Permitted Internal Activity** and **Publishing About This Work**
->   sections are custom business terms.
->
-> See the closing note about legal review.
+<https://polyformproject.org/licenses/internal-use/1.0.0>
 
 ## Acceptance
 
-In order to get any license under these terms, Oura must agree to them as
-both strict obligations and conditions to all of Oura's licenses.
-
-## Parties and Definitions
-
-The **Licensor** is Nathan Heaps, the individual offering these terms. The
-**software** is the software the Licensor makes available under these terms.
-
-The **Licensee**, referred to as **"Oura"**, is Oura Health Oy together with
-its affiliates, including Oura Ring Inc., and no one else. An **affiliate**
-is any legal entity that controls, is controlled by, or is under common
-control with Oura Health Oy, where **control** means ownership of
-substantially all the assets of an entity, or the power to direct its
-management and policies by vote, contract, or otherwise, whether direct or
-indirect.
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
 
 ## Copyright License
 
-The Licensor grants Oura a perpetual, worldwide, royalty-free copyright
-license for the software to do everything Oura might do with the software
-that would otherwise infringe the Licensor's copyright in it for the
-Permitted Purpose. However, Oura may only make changes or new works based on
-the software according to the "Changes and New Works License" below, and Oura
-may not distribute the software except as expressly permitted under
-"Publishing About This Work" below.
+The licensor grants you a copyright license for the software
+to do everything you might do with the software that would
+otherwise infringe the licensor's copyright in it for any
+permitted purpose.  However, you may only make changes or
+new works based on the software according to [Changes and New
+Works License](#changes-and-new-works-license), and you may
+not distribute the software.
 
 ## Changes and New Works License
 
-The Licensor grants Oura an additional copyright license to make changes and
-new works based on the software for the Permitted Purpose.
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
 
 ## Patent License
 
-_(This section is modeled on Apache License 2.0, Section 3, "Grant of Patent
-License.")_
-
-Subject to the terms and conditions of this license, the Licensor hereby
-grants to Oura a perpetual, worldwide, non-exclusive, no-charge,
-royalty-free, irrevocable (except as stated in this section) patent license
-to make, have made, use, offer to sell, sell, import, and otherwise transfer
-the software, where such license applies only to those patent claims
-licensable by the Licensor that are necessarily infringed by the software
-alone or by combination of the software with Oura's use of it for the
-Permitted Purpose. If Oura institutes patent litigation against any entity
-(including a cross-claim or counterclaim in a lawsuit) alleging that the
-software constitutes direct or contributory patent infringement, then any
-patent licenses granted to Oura under this license for the software shall
-terminate as of the date such litigation is filed.
-
-## Permitted Purpose
-
-Use of the software for the internal business operations of Oura is use for
-the Permitted Purpose. This license does not grant any right to use the
-software to provide a product or service to anyone outside Oura.
-
-## Permitted Internal Activity
-
-Oura may maintain, modify, and fork the software internally for its own use
-for the Permitted Purpose, provided that attribution to the original author
-(Nathan Heaps) is preserved in any copy, fork, or derivative work.
-
-## Publishing About This Work
-
-Oura may write, publish, and distribute articles, blog posts, or other
-public materials describing the techniques, architecture, or approach used
-in the software. Any code accompanying such publications must be an
-independent implementation that expresses only the general techniques
-described in the publication — it must not be a copy, fork, or derivative of
-this source code, and must not expose this source directly.
-
-## No Trademark License
-
-_(This section is modeled on Apache License 2.0, Section 6, "Trademarks.")_
-
-This license does not grant permission to use the trade names, trademarks,
-service marks, product names, or logos of the Licensor, except as required
-for reasonable and customary use in describing the origin of the software and
-preserving the attribution required above.
-
-## No Other Rights
-
-These terms do not allow Oura to sublicense or transfer any of its licenses
-to anyone else, or prevent the Licensor from granting licenses to anyone
-else. These terms do not imply any other licenses. All rights not expressly
-granted above are reserved by the Licensor.
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
 
 ## Fair Use
 
-Oura may have "fair use" rights for the software under the law. These terms
-do not limit them.
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## Internal Business Use
+
+Use of the software for the internal business operations of
+you and your company is use for a permitted purpose.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
 
 ## Violations
 
-The first time Oura is notified in writing that it has violated any of these
-terms, or done anything with the software not covered by its licenses, Oura's
-licenses can nonetheless continue if Oura comes into full compliance with
-these terms, and takes practical steps to correct past violations, within 32
-days of receiving notice. Otherwise, all of Oura's licenses end immediately.
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
 
-## No Warranty
+## No Liability
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OR CONDITION OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. AS
-FAR AS THE LAW ALLOWS, IN NO EVENT SHALL THE LICENSOR BE LIABLE FOR ANY
-CLAIM, DAMAGES, OR OTHER LIABILITY ARISING OUT OF THESE TERMS OR THE USE OR
-NATURE OF THE SOFTWARE, UNDER ANY KIND OF LEGAL CLAIM.
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
 
----
+## Definitions
 
-_Note: this license combines real, standardized license language — the
-**PolyForm Internal Use License 1.0.0** as its base, with a patent grant and
-trademark clause modeled on **Apache License 2.0** (Sections 3 and 6) — with
-custom business terms specified by the author (single named licensee,
-internal forks with preserved attribution, and the publication /
-independent-reimplementation carve-out). It has been adapted by hand and has
-**not** been reviewed by an attorney. PolyForm and Apache are used here as
-drafting sources, not as unmodified license grants, and this combination is
-not itself a certified/standard license. Obtain legal review before relying
-on it._
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.


### PR DESCRIPTION
Updated the license terms to reflect changes in the licensee from 'Oura' to 'you and your company'. Adjusted sections to generalize the language for broader applicability.

<!--
  Org-wide PR template — SYNCED from nsheaps/.github
  (ansible/templates/.github/pull_request_template.md). Local edits are
  replaced on the next org sync run; propose changes upstream instead.

  Delete any section that genuinely does not apply. Do not delete
  "Blast radius" or "Validation performed" — if they are empty, say why.
-->

## What changed

<!--
  The actual diff, file by file, in the order a reviewer should read it.
  A table works well when several files change for different reasons.
  Link to specific lines (`path/to/file.py:120-134`) rather than describing.
-->

## Why

<!--
  The problem or requirement this serves. If it came from an issue, a
  review comment, or an incident, link it. "Because it was asked for" is
  a real reason — say who asked and where.
-->

## Blast radius

<!--
  READ THIS SECTION BEFORE APPROVING.

  Answer concretely:
    - What is affected? (this repo only / N managed repos / all org members)
    - When does it take effect? (on merge / on next sync / only for new repos)
    - What breaks if this is wrong? What is the rollback?
    - What existing behaviour or local decision does this override?

  If the change is genuinely inert today (feature-flagged, enforcement
  disabled, no consumer yet), say so AND say what would make it live.
-->

## Validation performed

<!--
  Paste REAL output — command invocations and their actual results. Not
  "tests pass", not a description of what you would run.

  Where a test is meant to catch a regression, show that it actually fails
  without the fix. An assertion that never fails is not validation.
-->

```
$ <command>
<output>
```

## What a reviewer should scrutinise

<!--
  The parts you are least sure about, the trade-offs you made, and any
  decision you made unilaterally that the reviewer might have made
  differently. Pre-empt the strongest objection to this PR rather than
  waiting for review to find it.
-->

1.
2.

## Related

<!-- Issues, prior PRs, specs, Discord threads. Use "Closes #N" to auto-close. -->

-
